### PR TITLE
Fix github.com/go-check/check version number

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -2,6 +2,8 @@ module github.com/mlogclub/bbs-go
 
 go 1.13
 
+replace github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
+
 require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/aliyun/aliyun-oss-go-sdk v1.9.8


### PR DESCRIPTION
This is an untagged commit ID, so the version should start with "v0.0.0" instead of "v1.0.0".
https://github.com/flosch/pongo2/commit/bbf5a6c351f4d4e883daa40046a404d7553e0a00