### PR TITLE
Containerize

### DIFF
--- a/.docker-compose/mysql/db/conf.d/my.cnf
+++ b/.docker-compose/mysql/db/conf.d/my.cnf
@@ -1,0 +1,13 @@
+[client]
+default-character-set=utf8
+
+[mysql]
+default-character-set=utf8
+
+[mysqld]
+collation-server=utf8_unicode_ci
+character-set-server=utf8
+
+skip-host-cache
+skip-name-resolve #https://www.percona.com/blog/2008/05/31/dns-achilles-heel-mysql-installation/
+performance_schema=OFF

--- a/.docker-compose/mysql/db/docker-entrypoint-initdb.d/init-db.sql
+++ b/.docker-compose/mysql/db/docker-entrypoint-initdb.d/init-db.sql
@@ -1,0 +1,212 @@
+CREATE DATABASE IF NOT EXISTS `mlog_db`;
+
+
+USE mlog_db;
+SET NAMES UTF8;
+
+-- 初始化用户表
+CREATE TABLE IF NOT EXISTS `t_user` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `username` varchar(32) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `email` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `nickname` varchar(16) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `avatar` text COLLATE utf8_unicode_ci,
+  `password` varchar(512) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `status` int(11) NOT NULL,
+  `roles` text COLLATE utf8_unicode_ci,
+  `type` int(11) NOT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  `create_time` bigint(20) DEFAULT NULL,
+  `update_time` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `email` (`email`),
+  KEY `idx_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- 初始化用户数据（用户名：admin、密码：123456）
+INSERT INTO t_user (
+    `id`,
+    `username`,
+    `nickname`,
+    `avatar`,
+    `email`,
+    `password`,
+    `status`,
+    `create_time`,
+    `update_time`,
+    `roles`,
+    `type`,
+    `description`
+) SELECT
+    1,
+    'admin',
+    '管理员',
+    '',
+    'a@example.com',
+    '$2a$10$ofA39bAFMpYpIX/Xiz7jtOMH9JnPvYfPRlzHXqAtLPFpbE/cLdjmS',
+    0,
+    1555419028975,
+    1555419028975,
+    '管理员',
+    0,
+    '轻轻地我走了，正如我轻轻的来。'
+FROM
+    DUAL
+WHERE
+    NOT EXISTS (
+        SELECT
+            `id`,
+            `username`,
+            `nickname`,
+            `avatar`,
+            `email`,
+            `password`,
+            `status`,
+            `create_time`,
+            `update_time`,
+            `roles`,
+            `type`,
+            `description`
+        FROM t_user
+        WHERE id = 1
+    );
+
+-- 初始化系统配置表
+CREATE TABLE IF NOT EXISTS `t_sys_config` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `key` varchar(128) COLLATE utf8_unicode_ci NOT NULL,
+  `value` text COLLATE utf8_unicode_ci,
+  `name` varchar(32) COLLATE utf8_unicode_ci NOT NULL,
+  `description` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `create_time` bigint(20) NOT NULL,
+  `update_time` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `key` (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- 初始化系统配置数据
+INSERT INTO t_sys_config(
+    `key`,
+    `value`,
+    `name`,
+    `description`,
+    `create_time`,
+    `update_time`
+) SELECT
+    'site.title',
+    'M-LOG',
+    '站点标题',
+    '站点标题',
+    1555419028975,
+    1555419028975
+FROM
+    DUAL
+WHERE
+    NOT EXISTS (
+        SELECT
+            `key`,
+            `value`,
+            `name`,
+            `description`,
+            `create_time`,
+            `update_time`
+        FROM
+            t_sys_config
+        WHERE
+            `key` = 'site.title'
+    );
+
+INSERT INTO t_sys_config (
+    `key`,
+    `value`,
+    `name`,
+    `description`,
+    `create_time`,
+    `update_time`
+) SELECT
+    'site.description',
+    'M-LOG社区，基于Go语言的开源社区系统',
+    '站点描述',
+    '站点描述',
+    1555419028975,
+    1555419028975
+FROM
+    DUAL
+WHERE
+    NOT EXISTS (
+        SELECT
+            `key`,
+            `value`,
+            `name`,
+            `description`,
+            `create_time`,
+            `update_time`
+        FROM
+            t_sys_config
+        WHERE
+            `key` = 'site.description'
+    );
+
+INSERT INTO t_sys_config (
+    `key`,
+    `value`,
+    `name`,
+    `description`,
+    `create_time`,
+    `update_time`
+) SELECT
+    'site.keywords',
+    'M-LOG,Go语言',
+    '站点关键字',
+    '站点关键字',
+    1555419028975,
+    1555419028975
+FROM
+    DUAL
+WHERE
+    NOT EXISTS (
+        SELECT
+            `key`,
+            `value`,
+            `name`,
+            `description`,
+            `create_time`,
+            `update_time`
+        FROM
+            t_sys_config
+        WHERE
+            `key` = 'site.keywords'
+    );
+
+
+INSERT INTO t_sys_config (
+    `key`,
+    `value`,
+    `name`,
+    `description`,
+    `create_time`,
+    `update_time`
+) SELECT
+    'recommend.tags',
+    '',
+    '推荐标签',
+    '推荐标签，多个标签之间用英文逗号分隔',
+    1555419028975,
+    1555419028975
+FROM
+    DUAL
+WHERE
+    NOT EXISTS (
+        SELECT
+            `key`,
+            `value`,
+            `name`,
+            `description`,
+            `create_time`,
+            `update_time`
+        FROM
+            t_sys_config
+        WHERE
+            `key` = 'recommend.tags'
+    );

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 dist
 package-lock.json
+*.log

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,0 +1,78 @@
+# builder stage
+FROM node:10.16-slim AS builder
+
+# Install build dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+      build-essential \
+      git \
+      openssh-client \
+      locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale: https://daten-und-bass.io/blog/fixing-missing-locale-setting-in-ubuntu-docker-image/
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Update timezone
+ENV TZ=Asia/Shanghai
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json* ./
+RUN npm i
+
+FROM builder AS assets
+
+# Copy application code
+COPY . .
+
+# Build project
+RUN npm run build
+
+# Remove unused dependencies
+#ARG NPM_PRUNE_FLAGS
+#RUN npm prune ${NPM_PRUNE_FLAGS}
+
+# application stage
+FROM node:10.16-slim AS application
+
+# Install runtime dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+      curl \
+      locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale: https://daten-und-bass.io/blog/fixing-missing-locale-setting-in-ubuntu-docker-image/
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Update timezone
+ENV TZ=Asia/Shanghai
+
+EXPOSE 8080
+
+HEALTHCHECK --start-period=10s \
+            --interval=15s \
+            --timeout=5s \
+            --retries=3 \
+            CMD curl -sSf http://localhost:8080/heartbeat || exit 1
+
+WORKDIR /app
+
+# Install serve
+RUN npm i -g serve
+
+# node_modules from former assets stage
+COPY --from=assets /app/dist /app/dist
+#CMD ["serve", "-s", "dist", "-l", "8080"] # dont know why it dont not work,
+
+COPY --from=assets /app/node_modules /app/node_modules
+COPY . .
+CMD ["npm", "run", "serve"]

--- a/admin/src/apis/HttpClient.js
+++ b/admin/src/apis/HttpClient.js
@@ -7,6 +7,7 @@ class HttpClient {
     this.http = axios.create({
       // baseURL: 'https://mlog.club'
       baseURL: 'http://localhost:8082'
+      // baseURL: process.env.APP_BASE_URL
     });
     this.http.defaults.headers.common['X-Client'] = 'bbs-go-admin';
     this.http.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+services:
+  db:
+    ports:
+      - '3309:3306'
+  bbs-go-server:
+    ports:
+      - '8082:8082'
+  bbs-go-admin:
+    build:
+      args:
+        NPM_PRUNE_FLAGS: '--production'
+    environment:
+      APP_BASE_URL: 'http://localhost:8082'
+    ports:
+      - '8080:8080'
+  bbs-go-site:
+    build:
+      args:
+        NPM_PRUNE_FLAGS: '--production'
+    ports:
+      - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.7'
+services:
+  bbs-go-server:
+    build:
+      target: application
+      context: server
+    image: mlogclub/bbs-go-server
+    depends_on:
+      - start_dependencies
+    environment:
+      - APP_ENV
+    restart: on-failure
+    volumes:
+      - './data:/data/'
+
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - db
+    command: db:3306
+
+  bbs-go-admin:
+    build:
+      target: application
+      context: admin
+    image: mlogclub/bbs-go-admin
+    depends_on:
+      - bbs-go-server
+    environment:
+      - APP_ENV
+    restart: on-failure
+
+  bbs-go-site:
+    build:
+      target: application
+      context: site
+    image: mlogclub/bbs-go-site
+    depends_on:
+      - bbs-go-server
+    environment:
+      - APP_ENV
+    restart: on-failure
+
+  db:
+    image: 'mysql:5.7'
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - '.docker-compose/mysql/db/conf.d:/etc/mysql/conf.d'
+      - '.docker-compose/mysql/db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d'
+
+volumes:
+  bbs-go-server: {}
+  db: {}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -22,3 +22,5 @@ build/*
 
 cscope.files
 tags
+
+logs/*.log

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,54 @@
+# builder stage
+FROM golang:1.13-stretch AS builder
+
+# Install build dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+      build-essential \
+      git \
+      openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Update timezone
+ENV TZ=Asia/Shanghai
+
+WORKDIR /app
+
+ENV GO111MODULE=on
+ENV ROOT_DIR=/app
+
+# download and cache go dependencies
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o bbs-go-server
+
+# application stage
+FROM debian:stretch-slim as application
+
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends ca-certificates curl \
+    && apt-get -qq install -y host mysql-client\
+    && rm -rf /var/lib/apt/lists/*
+
+# Update timezone
+ENV TZ=Asia/Shanghai
+ENV ROOT_DIR=/app
+
+COPY --from=builder /app/bbs-go-server .
+COPY --from=builder /app/bbs-go.yaml bbs-go.yaml
+
+EXPOSE 8080
+
+HEALTHCHECK --start-period=10s \
+            --interval=15s \
+            --timeout=5s \
+            --retries=3 \
+            CMD curl -sSf http://localhost:8082/api/img/proxy || exit 1
+
+CMD ["./bbs-go-server"]

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,0 +1,36 @@
+# builder stage
+FROM node:10.16-slim AS builder
+
+# Install build dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+      build-essential \
+      git \
+      openssh-client \
+      locales \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale: https://daten-und-bass.io/blog/fixing-missing-locale-setting-in-ubuntu-docker-image/
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Update timezone
+ENV TZ=Asia/Shanghai
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json* ./
+RUN npm i
+
+FROM builder AS application
+
+# Copy application code
+COPY . .
+
+# Build project
+RUN npm run build
+
+CMD ["npm", "run", "start"]

--- a/site/components/MyNav.vue
+++ b/site/components/MyNav.vue
@@ -98,7 +98,7 @@
 <script>
 import utils from '~/common/utils'
 import GithubLogin from '~/components/GithubLogin'
-import QqLogin from '~/components/QqLogin'
+import QqLogin from '~/components/QQLogin'
 export default {
   components: { GithubLogin, QqLogin },
   data() {

--- a/site/nuxt.config.js.example
+++ b/site/nuxt.config.js.example
@@ -1,6 +1,4 @@
 export default {
-  host: '0.0.0.0',
-  port: 3000,
   mode: 'universal',
   /*
    ** Headers of the page
@@ -75,7 +73,6 @@ export default {
   },
 
   proxy: {
-    // '/api/': 'http://localhost:8082'
     '/api/': 'http://bbs-go-server:8082'
     // '/api/': 'https://mlog.club/'
   },

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/code-frame/download/@babel/code-frame-7.5.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/code-frame/download/@babel/code-frame-7.5.5.tgz?cache=0&sync_timestamp=1563398593063&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fcode-frame%2Fdownload%2F%40babel%2Fcode-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "requires": {
         "@babel/highlight": "^7.0.0"
@@ -188,7 +188,7 @@
     },
     "@babel/helper-regex": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-regex/download/@babel/helper-regex-7.5.5.tgz?cache=0&sync_timestamp=1563398528521&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fhelper-regex%2Fdownload%2F%40babel%2Fhelper-regex-7.5.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/helper-regex/download/@babel/helper-regex-7.5.5.tgz",
       "integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
       "requires": {
         "lodash": "^4.17.13"
@@ -301,7 +301,7 @@
     },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-dynamic-import/download/@babel/plugin-proposal-dynamic-import-7.5.0.tgz?cache=0&sync_timestamp=1562245130508&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-proposal-dynamic-import%2Fdownload%2F%40babel%2Fplugin-proposal-dynamic-import-7.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-dynamic-import/download/@babel/plugin-proposal-dynamic-import-7.5.0.tgz",
       "integrity": "sha1-5TIgLbSDhyNpGxCme4zlCeOXxQY=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -411,7 +411,7 @@
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-async-to-generator/download/@babel/plugin-transform-async-to-generator-7.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-async-to-generator/download/@babel/plugin-transform-async-to-generator-7.5.0.tgz?cache=0&sync_timestamp=1562245140908&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-transform-async-to-generator%2Fdownload%2F%40babel%2Fplugin-transform-async-to-generator-7.5.0.tgz",
       "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -479,7 +479,7 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-duplicate-keys/download/@babel/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-duplicate-keys/download/@babel/plugin-transform-duplicate-keys-7.5.0.tgz?cache=0&sync_timestamp=1562245140778&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-transform-duplicate-keys%2Fdownload%2F%40babel%2Fplugin-transform-duplicate-keys-7.5.0.tgz",
       "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -529,7 +529,7 @@
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-amd/download/@babel/plugin-transform-modules-amd-7.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-amd/download/@babel/plugin-transform-modules-amd-7.5.0.tgz?cache=0&sync_timestamp=1562245140815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-transform-modules-amd%2Fdownload%2F%40babel%2Fplugin-transform-modules-amd-7.5.0.tgz",
       "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
@@ -550,7 +550,7 @@
     },
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-systemjs/download/@babel/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-systemjs/download/@babel/plugin-transform-modules-systemjs-7.5.0.tgz?cache=0&sync_timestamp=1562245135498&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fplugin-transform-modules-systemjs%2Fdownload%2F%40babel%2Fplugin-transform-modules-systemjs-7.5.0.tgz",
       "integrity": "sha1-51JmoT75QgLbKgYgl3dW9R1S0kk=",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
@@ -639,7 +639,7 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627367398&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
@@ -942,7 +942,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "string-width": {
@@ -956,7 +956,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -1182,7 +1182,7 @@
     },
     "@types/q": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.2.tgz?cache=0&sync_timestamp=1567534086032&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.2.tgz",
       "integrity": "sha1-aQoUdbhPKohP0HzXl8APXzE1bqg="
     },
     "@typescript-eslint/experimental-utils": {
@@ -1336,7 +1336,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz?cache=0&sync_timestamp=1569874223546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyallist%2Fdownload%2Fyallist-2.1.2.tgz",
+          "resolved": "http://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
@@ -1625,7 +1625,7 @@
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://registry.npm.taobao.org/ansi-colors/download/ansi-colors-3.2.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/ansi-colors/download/ansi-colors-3.2.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-colors%2Fdownload%2Fansi-colors-3.2.4.tgz",
       "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78="
     },
     "ansi-escapes": {
@@ -1643,12 +1643,12 @@
     },
     "ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-4.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
       "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&sync_timestamp=1566430562325&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
@@ -1665,7 +1665,7 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/aproba/download/aproba-1.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/aproba/download/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
@@ -1695,7 +1695,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -1729,7 +1729,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/array-equal/download/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/array-equal/download/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -1787,7 +1787,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
@@ -1823,7 +1823,7 @@
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/async-foreach/download/async-foreach-0.1.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/async-foreach/download/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
@@ -1885,7 +1885,7 @@
         },
         "follow-redirects": {
           "version": "1.5.10",
-          "resolved": "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.5.10.tgz?cache=0&sync_timestamp=1567775546836&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.5.10.tgz",
+          "resolved": "http://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.5.10.tgz",
           "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
           "requires": {
             "debug": "=3.1.0"
@@ -1923,17 +1923,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&sync_timestamp=1566430562325&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz?cache=0&sync_timestamp=1570527339087&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-1.1.3.tgz",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1950,7 +1950,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1958,7 +1958,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
@@ -1990,7 +1990,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -1998,7 +1998,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-dynamic-import-node/download/babel-plugin-dynamic-import-node-2.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbabel-plugin-dynamic-import-node%2Fdownload%2Fbabel-plugin-dynamic-import-node-2.3.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/babel-plugin-dynamic-import-node/download/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
       "requires": {
         "object.assign": "^4.1.0"
@@ -2015,14 +2015,14 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-runtime%2Fdownload%2Fregenerator-runtime-0.11.1.tgz",
           "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
         }
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -2046,7 +2046,7 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "https://registry.npm.taobao.org/globals/download/globals-9.18.0.tgz?cache=0&sync_timestamp=1570510896643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-9.18.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/globals/download/globals-9.18.0.tgz?cache=0&sync_timestamp=1563721993391&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-9.18.0.tgz",
           "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
         },
         "ms": {
@@ -2058,7 +2058,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://registry.npm.taobao.org/babel-types/download/babel-types-6.26.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbabel-types%2Fdownload%2Fbabel-types-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-types/download/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2076,7 +2076,7 @@
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://registry.npm.taobao.org/babylon/download/babylon-6.18.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babylon/download/babylon-6.18.0.tgz",
       "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "balanced-match": {
@@ -2189,7 +2189,7 @@
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbody-parser%2Fdownload%2Fbody-parser-1.19.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
@@ -2219,7 +2219,7 @@
         },
         "http-errors": {
           "version": "1.7.2",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz?cache=0&sync_timestamp=1561418493658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz?cache=0&sync_timestamp=1561418526117&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.2.tgz",
           "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
           "requires": {
             "depd": "~1.1.2",
@@ -2231,7 +2231,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ms": {
@@ -2241,7 +2241,7 @@
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1569207136481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         }
       }
@@ -2309,7 +2309,7 @@
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/browser-process-hrtime/download/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/browser-process-hrtime/download/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q="
     },
     "browserify-aes": {
@@ -2389,7 +2389,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2536,7 +2536,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz?cache=0&sync_timestamp=1562668933683&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcaller-callsite%2Fdownload%2Fcaller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz?cache=0&sync_timestamp=1562668966653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcaller-callsite%2Fdownload%2Fcaller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
         "callsites": "^2.0.0"
@@ -2571,7 +2571,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/camelcase-keys/download/camelcase-keys-2.1.0.tgz?cache=0&sync_timestamp=1571401100330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamelcase-keys%2Fdownload%2Fcamelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/camelcase-keys/download/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -2616,7 +2616,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz?cache=0&sync_timestamp=1570527339087&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-2.4.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -2632,7 +2632,7 @@
     },
     "check-types": {
       "version": "8.0.3",
-      "resolved": "https://registry.npm.taobao.org/check-types/download/check-types-8.0.3.tgz?cache=0&sync_timestamp=1571636786834&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcheck-types%2Fdownload%2Fcheck-types-8.0.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/check-types/download/check-types-8.0.3.tgz?cache=0&sync_timestamp=1563541272390&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcheck-types%2Fdownload%2Fcheck-types-8.0.3.tgz",
       "integrity": "sha1-M1bMoZyIlUTy16le1JzlCKDs9VI="
     },
     "chokidar": {
@@ -2756,7 +2756,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-cursor%2Fdownload%2Fcli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -2782,13 +2782,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -2808,7 +2808,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2829,7 +2829,7 @@
     },
     "clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/clone-deep/download/clone-deep-4.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/clone-deep/download/clone-deep-4.0.1.tgz",
       "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
       "dev": true,
       "requires": {
@@ -2874,7 +2874,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcolor-convert%2Fdownload%2Fcolor-convert-1.9.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "requires": {
         "color-name": "1.1.3"
@@ -2927,7 +2927,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npm.taobao.org/compression/download/compression-1.7.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/compression/download/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "requires": {
         "accepts": "~1.3.5",
@@ -2986,7 +2986,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -3085,7 +3085,7 @@
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/contains-path/download/contains-path-0.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/contains-path/download/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
@@ -3272,7 +3272,7 @@
     },
     "css-blank-pseudo": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/css-blank-pseudo/download/css-blank-pseudo-0.1.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/css-blank-pseudo/download/css-blank-pseudo-0.1.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-blank-pseudo%2Fdownload%2Fcss-blank-pseudo-0.1.4.tgz",
       "integrity": "sha1-3979MlS/ioICeZNnTM81SDv8s8U=",
       "requires": {
         "postcss": "^7.0.5"
@@ -3294,7 +3294,7 @@
     },
     "css-has-pseudo": {
       "version": "0.10.0",
-      "resolved": "https://registry.npm.taobao.org/css-has-pseudo/download/css-has-pseudo-0.10.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/css-has-pseudo/download/css-has-pseudo-0.10.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-has-pseudo%2Fdownload%2Fcss-has-pseudo-0.10.0.tgz",
       "integrity": "sha1-PGQqs0yiQsWcQaEl35EFhB9pZu4=",
       "requires": {
         "postcss": "^7.0.6",
@@ -3377,7 +3377,7 @@
     },
     "css-what": {
       "version": "2.1.3",
-      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-2.1.3.tgz?cache=0&sync_timestamp=1564773794818&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-2.1.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-2.1.3.tgz?cache=0&sync_timestamp=1563844282165&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-2.1.3.tgz",
       "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI="
     },
     "cssdb": {
@@ -3463,7 +3463,7 @@
     },
     "csso": {
       "version": "3.5.1",
-      "resolved": "https://registry.npm.taobao.org/csso/download/csso-3.5.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/csso/download/csso-3.5.1.tgz",
       "integrity": "sha1-e564vmFiiXPBsmHhadLwJACOdYs=",
       "requires": {
         "css-tree": "1.0.0-alpha.29"
@@ -3480,7 +3480,7 @@
         },
         "mdn-data": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-1.1.4.tgz?cache=0&sync_timestamp=1562672674261&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmdn-data%2Fdownload%2Fmdn-data-1.1.4.tgz",
+          "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-1.1.4.tgz",
           "integrity": "sha1-ULXU/8RXUnZXPE7tuHgIEqhBnwE="
         }
       }
@@ -3492,7 +3492,7 @@
     },
     "cssstyle": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/cssstyle/download/cssstyle-1.4.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/cssstyle/download/cssstyle-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssstyle%2Fdownload%2Fcssstyle-1.4.0.tgz",
       "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "requires": {
         "cssom": "0.3.x"
@@ -3500,7 +3500,7 @@
     },
     "cuint": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/cuint/download/cuint-0.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/cuint/download/cuint-0.2.2.tgz",
       "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
     },
     "currently-unhandled": {
@@ -3611,7 +3611,7 @@
     },
     "d3-drag": {
       "version": "1.2.4",
-      "resolved": "https://registry.npm.taobao.org/d3-drag/download/d3-drag-1.2.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/d3-drag/download/d3-drag-1.2.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fd3-drag%2Fdownload%2Fd3-drag-1.2.4.tgz",
       "integrity": "sha1-upMx1oFYrRTPC0soqK+p54x9ma0=",
       "requires": {
         "d3-dispatch": "1",
@@ -3727,7 +3727,7 @@
     },
     "d3-shape": {
       "version": "1.3.5",
-      "resolved": "https://registry.npm.taobao.org/d3-shape/download/d3-shape-1.3.5.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fd3-shape%2Fdownload%2Fd3-shape-1.3.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/d3-shape/download/d3-shape-1.3.5.tgz",
       "integrity": "sha1-6BrqWUD1nwp5z8ysASIyqJh8YDM=",
       "requires": {
         "d3-path": "1"
@@ -3809,7 +3809,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/data-urls/download/data-urls-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/data-urls/download/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "requires": {
         "abab": "^2.0.0",
@@ -3849,7 +3849,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdecamelize%2Fdownload%2Fdecamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -4022,12 +4022,12 @@
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz",
       "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/domexception/download/domexception-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/domexception/download/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "requires": {
         "webidl-conversions": "^4.0.2"
@@ -4035,7 +4035,7 @@
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz",
       "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "requires": {
         "domelementtype": "1"
@@ -4043,7 +4043,7 @@
     },
     "domutils": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz",
       "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
       "requires": {
         "dom-serializer": "0",
@@ -4096,7 +4096,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -4358,7 +4358,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -4386,13 +4386,13 @@
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz",
+          "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fignore%2Fdownload%2Fignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         },
         "import-fresh": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-3.1.0.tgz?cache=0&sync_timestamp=1561888919431&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-3.1.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-3.1.0.tgz?cache=0&sync_timestamp=1561888921017&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-3.1.0.tgz",
           "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
           "dev": true,
           "requires": {
@@ -4435,7 +4435,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -4461,7 +4461,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://registry.npm.taobao.org/eslint-import-resolver-node/download/eslint-import-resolver-node-0.3.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/eslint-import-resolver-node/download/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "requires": {
@@ -4488,7 +4488,7 @@
     },
     "eslint-loader": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/eslint-loader/download/eslint-loader-2.2.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/eslint-loader/download/eslint-loader-2.2.1.tgz?cache=0&sync_timestamp=1562235844038&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-loader%2Fdownload%2Feslint-loader-2.2.1.tgz",
       "integrity": "sha1-KLnBLaVAV68IReKmEScBova/gzc=",
       "dev": true,
       "requires": {
@@ -4545,7 +4545,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "dev": true,
           "requires": {
@@ -4690,7 +4690,7 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-4.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-scope%2Fdownload%2Feslint-scope-4.0.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-4.0.3.tgz",
       "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "requires": {
         "esrecurse": "^4.1.0",
@@ -4719,7 +4719,7 @@
     },
     "espree": {
       "version": "5.0.1",
-      "resolved": "https://registry.npm.taobao.org/espree/download/espree-5.0.1.tgz?cache=0&sync_timestamp=1571624368510&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fespree%2Fdownload%2Fespree-5.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/espree/download/espree-5.0.1.tgz?cache=0&sync_timestamp=1561171239020&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fespree%2Fdownload%2Fespree-5.0.1.tgz",
       "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
       "dev": true,
       "requires": {
@@ -4808,7 +4808,7 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/exit/download/exit-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/exit/download/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
@@ -4913,7 +4913,7 @@
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1569207136481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
         }
       }
@@ -4944,7 +4944,7 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/external-editor/download/external-editor-3.1.0.tgz?cache=0&sync_timestamp=1562602052556&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexternal-editor%2Fdownload%2Fexternal-editor-3.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/external-editor/download/external-editor-3.1.0.tgz",
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "dev": true,
       "requires": {
@@ -5026,7 +5026,7 @@
       "dependencies": {
         "normalize-url": {
           "version": "1.9.1",
-          "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnormalize-url%2Fdownload%2Fnormalize-url-1.9.1.tgz",
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -5037,7 +5037,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1567421597140&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "requires": {
             "ajv": "^6.1.0",
@@ -5054,7 +5054,7 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
@@ -5100,7 +5100,7 @@
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://registry.npm.taobao.org/filesize/download/filesize-3.6.1.tgz?cache=0&sync_timestamp=1570577090860&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffilesize%2Fdownload%2Ffilesize-3.6.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/filesize/download/filesize-3.6.1.tgz",
       "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc="
     },
     "fill-range": {
@@ -5195,13 +5195,13 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/flatted/download/flatted-2.0.1.tgz?cache=0&sync_timestamp=1561466276595&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fflatted%2Fdownload%2Fflatted-2.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/flatted/download/flatted-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fflatted%2Fdownload%2Fflatted-2.0.1.tgz",
       "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
       "dev": true
     },
     "flatten": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/flatten/download/flatten-1.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/flatten/download/flatten-1.0.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fflatten%2Fdownload%2Fflatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "flush-write-stream": {
@@ -5229,7 +5229,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5257,7 +5257,7 @@
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fform-data%2Fdownload%2Fform-data-2.3.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
         "asynckit": "^0.4.0",
@@ -5308,7 +5308,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5361,7 +5361,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5421,13 +5421,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -5447,7 +5447,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5521,7 +5521,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/global-dirs/download/global-dirs-0.1.1.tgz?cache=0&sync_timestamp=1568702365567&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobal-dirs%2Fdownload%2Fglobal-dirs-0.1.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/global-dirs/download/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -5530,7 +5530,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz?cache=0&sync_timestamp=1570510896643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-11.12.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz?cache=0&sync_timestamp=1563721993391&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
     },
     "globule": {
@@ -5546,7 +5546,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npm.taobao.org/got/download/got-6.7.1.tgz?cache=0&sync_timestamp=1569309347084&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgot%2Fdownload%2Fgot-6.7.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/got/download/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -5640,7 +5640,7 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627367398&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
@@ -5655,7 +5655,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -5663,7 +5663,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
@@ -5789,7 +5789,7 @@
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/html-encoding-sniffer/download/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/html-encoding-sniffer/download/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
       "requires": {
         "whatwg-encoding": "^1.0.1"
@@ -5816,7 +5816,7 @@
     },
     "html-tags": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/html-tags/download/html-tags-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-tags%2Fdownload%2Fhtml-tags-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/html-tags/download/html-tags-2.0.0.tgz",
       "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
     },
     "html-webpack-plugin": {
@@ -5840,7 +5840,7 @@
         },
         "commander": {
           "version": "2.17.1",
-          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78="
         },
         "html-minifier": {
@@ -5859,7 +5859,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "loader-utils": {
@@ -5880,7 +5880,7 @@
         },
         "uglify-js": {
           "version": "3.4.10",
-          "resolved": "https://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&sync_timestamp=1571839886837&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
+          "resolved": "https://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
           "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
           "requires": {
             "commander": "~2.19.0",
@@ -5889,7 +5889,7 @@
           "dependencies": {
             "commander": {
               "version": "2.19.0",
-              "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
+              "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz",
               "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
             }
           }
@@ -5898,7 +5898,7 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "https://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz",
       "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "requires": {
         "domelementtype": "^1.3.1",
@@ -5918,7 +5918,7 @@
     },
     "http-errors": {
       "version": "1.7.3",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.3.tgz?cache=0&sync_timestamp=1561418493658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.3.tgz?cache=0&sync_timestamp=1561418526117&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.3.tgz",
       "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
       "requires": {
         "depd": "~1.1.2",
@@ -5940,7 +5940,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&sync_timestamp=1567540944297&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
       "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
       "requires": {
         "http-proxy": "^1.17.0",
@@ -6002,7 +6002,7 @@
     },
     "ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/ignore-by-default/download/ignore-by-default-1.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/ignore-by-default/download/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
@@ -6016,7 +6016,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1561888919431&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1561888921017&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "requires": {
         "caller-path": "^2.0.0",
@@ -6044,7 +6044,7 @@
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/in-publish/download/in-publish-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/in-publish/download/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
@@ -6074,7 +6074,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
@@ -6112,7 +6112,7 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -6137,7 +6137,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+              "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -6174,7 +6174,7 @@
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz?cache=0&sync_timestamp=1569736493122&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-absolute-url%2Fdownload%2Fis-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
     "is-accessor-descriptor": {
@@ -6210,7 +6210,7 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz?cache=0&sync_timestamp=1569905495687&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-buffer%2Fdownload%2Fis-buffer-1.1.6.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-callable": {
@@ -6306,7 +6306,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
@@ -6329,7 +6329,7 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-npm/download/is-npm-1.0.0.tgz?cache=0&sync_timestamp=1571056897638&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-npm%2Fdownload%2Fis-npm-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-npm/download/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
@@ -6358,7 +6358,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-path-inside/download/is-path-inside-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-path-inside%2Fdownload%2Fis-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-path-inside/download/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -6451,7 +6451,7 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-1.1.0.tgz?cache=0&sync_timestamp=1569219566107&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-wsl%2Fdownload%2Fis-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
@@ -6495,7 +6495,7 @@
     },
     "js-base64": {
       "version": "2.5.1",
-      "resolved": "https://registry.npm.taobao.org/js-base64/download/js-base64-2.5.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/js-base64/download/js-base64-2.5.1.tgz",
       "integrity": "sha1-Hvo57yxfeYC7F4St5KivLeMpESE=",
       "dev": true
     },
@@ -6525,7 +6525,7 @@
     },
     "jsdom": {
       "version": "11.12.0",
-      "resolved": "https://registry.npm.taobao.org/jsdom/download/jsdom-11.12.0.tgz?cache=0&sync_timestamp=1571060460132&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjsdom%2Fdownload%2Fjsdom-11.12.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/jsdom/download/jsdom-11.12.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjsdom%2Fdownload%2Fjsdom-11.12.0.tgz",
       "integrity": "sha1-GoDUDd03ih3lllbp5txaO6hle8g=",
       "requires": {
         "abab": "^2.0.0",
@@ -6558,7 +6558,7 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.3",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-5.7.3.tgz?cache=0&sync_timestamp=1569334654641&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-5.7.3.tgz",
+          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-5.7.3.tgz",
           "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk="
         },
         "ws": {
@@ -6583,7 +6583,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz?cache=0&sync_timestamp=1567740732347&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson-schema%2Fdownload%2Fjson-schema-0.2.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -6644,7 +6644,7 @@
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/last-call-webpack-plugin/download/last-call-webpack-plugin-3.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/last-call-webpack-plugin/download/last-call-webpack-plugin-3.0.0.tgz",
       "integrity": "sha1-l0LfDhDjz0blwDgcLekNOnotdVU=",
       "requires": {
         "lodash": "^4.17.5",
@@ -6797,7 +6797,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-1.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/json5/download/json5-1.0.1.tgz",
           "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "requires": {
             "minimist": "^1.2.0"
@@ -6821,7 +6821,7 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz",
+      "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash%2Fdownload%2Flodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
     },
     "lodash._reinterpolate": {
@@ -6855,7 +6855,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.templatesettings/download/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/lodash.templatesettings/download/lodash.templatesettings-4.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash.templatesettings%2Fdownload%2Flodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
@@ -6863,7 +6863,7 @@
     },
     "lodash.unescape": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.unescape/download/lodash.unescape-4.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/lodash.unescape/download/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
@@ -6882,7 +6882,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/loud-rejection/download/loud-rejection-1.6.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floud-rejection%2Fdownload%2Floud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/loud-rejection/download/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -6920,7 +6920,7 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627367398&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
@@ -6937,7 +6937,7 @@
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/map-obj/download/map-obj-1.0.1.tgz?cache=0&sync_timestamp=1560578867343&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmap-obj%2Fdownload%2Fmap-obj-1.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/map-obj/download/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
@@ -6961,7 +6961,7 @@
     },
     "mdn-data": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.4.tgz?cache=0&sync_timestamp=1562672674261&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmdn-data%2Fdownload%2Fmdn-data-2.0.4.tgz",
+      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.4.tgz",
       "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs="
     },
     "media-typer": {
@@ -6971,7 +6971,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/memory-fs/download/memory-fs-0.4.1.tgz?cache=0&sync_timestamp=1570537491040&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmemory-fs%2Fdownload%2Fmemory-fs-0.4.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/memory-fs/download/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "^0.1.3",
@@ -6994,7 +6994,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -7091,7 +7091,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz?cache=0&sync_timestamp=1569564346247&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg-up%2Fdownload%2Fread-pkg-up-1.0.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -7168,7 +7168,7 @@
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://registry.npm.taobao.org/micromatch/download/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npm.taobao.org/micromatch/download/micromatch-3.1.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmicromatch%2Fdownload%2Fmicromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -7201,12 +7201,12 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://registry.npm.taobao.org/mime-db/download/mime-db-1.40.0.tgz?cache=0&sync_timestamp=1569468742433&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime-db%2Fdownload%2Fmime-db-1.40.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/mime-db/download/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI="
     },
     "mime-types": {
@@ -7310,7 +7310,7 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/mississippi/download/mississippi-3.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/mississippi/download/mississippi-3.0.0.tgz",
       "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "requires": {
         "concat-stream": "^1.5.0",
@@ -7429,7 +7429,7 @@
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://registry.npm.taobao.org/neo-async/download/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/neo-async/download/neo-async-2.6.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fneo-async%2Fdownload%2Fneo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw="
     },
     "nice-try": {
@@ -7539,7 +7539,7 @@
           "dependencies": {
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+              "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
               "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -7601,19 +7601,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&sync_timestamp=1566430562325&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz?cache=0&sync_timestamp=1570527339087&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-1.1.3.tgz",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7626,7 +7626,7 @@
         },
         "cross-spawn": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-3.0.1.tgz?cache=0&sync_timestamp=1570440024132&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcross-spawn%2Fdownload%2Fcross-spawn-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/cross-spawn/download/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
@@ -7646,7 +7646,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -7655,7 +7655,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
@@ -7670,7 +7670,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz?cache=0&sync_timestamp=1569874223546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyallist%2Fdownload%2Fyallist-2.1.2.tgz",
+          "resolved": "http://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -7696,7 +7696,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fanymatch%2Fdownload%2Fanymatch-2.0.0.tgz",
           "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "dev": true,
           "requires": {
@@ -8336,7 +8336,7 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1571011714883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1562457210009&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
           "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
           "dev": true,
           "requires": {
@@ -8353,7 +8353,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -8403,7 +8403,7 @@
     },
     "normalize-url": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnormalize-url%2Fdownload%2Fnormalize-url-3.3.0.tgz",
       "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk="
     },
     "npm-run-path": {
@@ -8504,7 +8504,7 @@
     },
     "object-hash": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/object-hash/download/object-hash-1.3.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/object-hash/download/object-hash-1.3.1.tgz",
       "integrity": "sha1-/eRSCYqVHLFF8Dm7fUVUSd3BJt8=",
       "dev": true
     },
@@ -8634,7 +8634,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-1.4.0.tgz?cache=0&sync_timestamp=1560274285880&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fos-locale%2Fdownload%2Fos-locale-1.4.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fos-locale%2Fdownload%2Fos-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -8693,7 +8693,7 @@
     },
     "package-json": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/package-json/download/package-json-4.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/package-json/download/package-json-4.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpackage-json%2Fdownload%2Fpackage-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
@@ -8742,7 +8742,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -8799,7 +8799,7 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-4.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/parse5/download/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg="
     },
     "parseurl": {
@@ -8809,7 +8809,7 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
@@ -8850,7 +8850,7 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
@@ -8922,7 +8922,7 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/pn/download/pn-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/pn/download/pn-1.1.0.tgz",
       "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs="
     },
     "posix-character-classes": {
@@ -8947,7 +8947,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-6.1.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
             "has-flag": "^3.0.0"
@@ -9258,7 +9258,7 @@
     },
     "postcss-import": {
       "version": "12.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-import/download/postcss-import-12.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/postcss-import/download/postcss-import-12.0.1.tgz",
       "integrity": "sha1-z4x6sLXMq1ZJAkU25WX4QZKLcVM=",
       "requires": {
         "postcss": "^7.0.1",
@@ -9303,7 +9303,7 @@
     },
     "postcss-load-config": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-load-config%2Fdownload%2Fpostcss-load-config-2.1.0.tgz",
       "integrity": "sha1-yE1pK3u3tB3c7ZTuYuirMbQXsAM=",
       "requires": {
         "cosmiconfig": "^5.0.0",
@@ -9323,7 +9323,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1567421597140&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "requires": {
             "ajv": "^6.1.0",
@@ -9704,7 +9704,7 @@
     },
     "postcss-preset-env": {
       "version": "6.7.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-preset-env/download/postcss-preset-env-6.7.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/postcss-preset-env/download/postcss-preset-env-6.7.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-preset-env%2Fdownload%2Fpostcss-preset-env-6.7.0.tgz",
       "integrity": "sha1-w03az4+QI4OzWtHgMPF49M3xGKU=",
       "requires": {
         "autoprefixer": "^9.6.1",
@@ -9879,7 +9879,7 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.4.4.tgz",
+          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz",
           "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
         }
       }
@@ -10023,7 +10023,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/pumpify/download/pumpify-1.5.1.tgz?cache=0&sync_timestamp=1569938200736&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpumpify%2Fdownload%2Fpumpify-1.5.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/pumpify/download/pumpify-1.5.1.tgz",
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "requires": {
         "duplexify": "^3.6.0",
@@ -10116,7 +10116,7 @@
         },
         "http-errors": {
           "version": "1.7.2",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz?cache=0&sync_timestamp=1561418493658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.2.tgz",
+          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz?cache=0&sync_timestamp=1561418526117&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.2.tgz",
           "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
           "requires": {
             "depd": "~1.1.2",
@@ -10128,7 +10128,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
@@ -10147,7 +10147,7 @@
     },
     "read-cache": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/read-cache/download/read-cache-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/read-cache/download/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "requires": {
         "pify": "^2.3.0"
@@ -10173,7 +10173,7 @@
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-2.0.0.tgz?cache=0&sync_timestamp=1569564346247&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg-up%2Fdownload%2Fread-pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
@@ -10202,7 +10202,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "dev": true,
           "requires": {
@@ -10280,12 +10280,12 @@
     },
     "regenerator-runtime": {
       "version": "0.13.3",
-      "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-runtime%2Fdownload%2Fregenerator-runtime-0.13.3.tgz",
       "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U="
     },
     "regenerator-transform": {
       "version": "0.14.1",
-      "resolved": "https://registry.npm.taobao.org/regenerator-transform/download/regenerator-transform-0.14.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-transform%2Fdownload%2Fregenerator-transform-0.14.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/regenerator-transform/download/regenerator-transform-0.14.1.tgz",
       "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "requires": {
         "private": "^0.1.6"
@@ -10302,7 +10302,7 @@
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/regexpp/download/regexpp-2.0.1.tgz?cache=0&sync_timestamp=1567160849322&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregexpp%2Fdownload%2Fregexpp-2.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/regexpp/download/regexpp-2.0.1.tgz",
       "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
       "dev": true
     },
@@ -10382,7 +10382,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "css-select": {
@@ -10398,7 +10398,7 @@
         },
         "domutils": {
           "version": "1.5.1",
-          "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "requires": {
             "dom-serializer": "0",
@@ -10407,7 +10407,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -10468,7 +10468,7 @@
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.5.2.tgz?cache=0&sync_timestamp=1569207136481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.5.2.tgz",
+          "resolved": "http://registry.npm.taobao.org/qs/download/qs-6.5.2.tgz",
           "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "tough-cookie": {
@@ -10569,7 +10569,7 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "http://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rewrite-imports": {
@@ -10642,7 +10642,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/safe-regex/download/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/safe-regex/download/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -10655,7 +10655,7 @@
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://registry.npm.taobao.org/sass-graph/download/sass-graph-2.2.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/sass-graph/download/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
@@ -10667,7 +10667,7 @@
     },
     "sass-loader": {
       "version": "7.3.1",
-      "resolved": "https://registry.npm.taobao.org/sass-loader/download/sass-loader-7.3.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsass-loader%2Fdownload%2Fsass-loader-7.3.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/sass-loader/download/sass-loader-7.3.1.tgz",
       "integrity": "sha1-pb9ooEvOocE/+ELXRxUPerfQ0j8=",
       "dev": true,
       "requires": {
@@ -10709,7 +10709,7 @@
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/scss-tokenizer/download/scss-tokenizer-0.2.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/scss-tokenizer/download/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -10735,7 +10735,7 @@
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/semver-diff/download/semver-diff-2.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/semver-diff/download/semver-diff-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver-diff%2Fdownload%2Fsemver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
@@ -10923,7 +10923,7 @@
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/slice-ansi/download/slice-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/slice-ansi/download/slice-ansi-2.1.0.tgz",
       "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
       "dev": true,
       "requires": {
@@ -11217,7 +11217,7 @@
     },
     "stdout-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/stdout-stream/download/stdout-stream-1.4.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/stdout-stream/download/stdout-stream-1.4.1.tgz",
       "integrity": "sha1-WsF0zdXNcmEEqgwLK9g4FdjVNd4=",
       "dev": true,
       "requires": {
@@ -11241,7 +11241,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -11280,7 +11280,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11299,7 +11299,7 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz",
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -11325,7 +11325,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11340,7 +11340,7 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
@@ -11360,7 +11360,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         }
       }
@@ -11400,7 +11400,7 @@
     },
     "strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "requires": {
         "ansi-regex": "^4.1.0"
@@ -11482,7 +11482,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-5.5.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "requires": {
         "has-flag": "^3.0.0"
@@ -11495,7 +11495,7 @@
     },
     "svgo": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/svgo/download/svgo-1.3.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/svgo/download/svgo-1.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsvgo%2Fdownload%2Fsvgo-1.3.0.tgz",
       "integrity": "sha1-uuUbqV3tmjOja3xGzpw1mukVQxM=",
       "requires": {
         "chalk": "^2.4.1",
@@ -11705,7 +11705,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11720,7 +11720,7 @@
     },
     "timed-out": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/timed-out/download/timed-out-4.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftimed-out%2Fdownload%2Ftimed-out-4.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/timed-out/download/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
@@ -11739,7 +11739,7 @@
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npm.taobao.org/tmp/download/tmp-0.0.33.tgz",
+      "resolved": "http://registry.npm.taobao.org/tmp/download/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
@@ -11796,7 +11796,7 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
     },
     "toposort": {
@@ -11806,7 +11806,7 @@
     },
     "touch": {
       "version": "3.1.0",
-      "resolved": "http://registry.npm.taobao.org/touch/download/touch-3.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/touch/download/touch-3.1.0.tgz",
       "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
       "dev": true,
       "requires": {
@@ -11835,7 +11835,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/tr46/download/tr46-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/tr46/download/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
@@ -11912,7 +11912,7 @@
     },
     "type-fest": {
       "version": "0.5.2",
-      "resolved": "https://registry.npm.taobao.org/type-fest/download/type-fest-0.5.2.tgz?cache=0&sync_timestamp=1569404138136&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftype-fest%2Fdownload%2Ftype-fest-0.5.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/type-fest/download/type-fest-0.5.2.tgz?cache=0&sync_timestamp=1562320018034&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftype-fest%2Fdownload%2Ftype-fest-0.5.2.tgz",
       "integrity": "sha1-1u9CoDVsbNRfSUhcO2KB/BSOSKI="
     },
     "type-is": {
@@ -11952,7 +11952,7 @@
     },
     "undefsafe": {
       "version": "2.0.2",
-      "resolved": "http://registry.npm.taobao.org/undefsafe/download/undefsafe-2.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/undefsafe/download/undefsafe-2.0.2.tgz",
       "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
       "dev": true,
       "requires": {
@@ -12150,7 +12150,7 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -12183,7 +12183,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz?cache=0&sync_timestamp=1570440024132&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcross-spawn%2Fdownload%2Fcross-spawn-5.1.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -12194,7 +12194,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npm.taobao.org/execa/download/execa-0.7.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/execa/download/execa-0.7.0.tgz?cache=0&sync_timestamp=1562315784630&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -12277,7 +12277,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -12313,7 +12313,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz?cache=0&sync_timestamp=1569874223546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyallist%2Fdownload%2Fyallist-2.1.2.tgz",
+          "resolved": "http://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -12365,7 +12365,7 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.4.4.tgz",
+          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz",
           "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
         }
       }
@@ -12394,7 +12394,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
@@ -12479,7 +12479,7 @@
     },
     "vue": {
       "version": "2.6.10",
-      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue%2Fdownload%2Fvue-2.6.10.tgz",
+      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.10.tgz",
       "integrity": "sha1-pysaQqTYKnIepDjRtr9V5mGVxjc="
     },
     "vue-client-only": {
@@ -12512,7 +12512,7 @@
         },
         "espree": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/espree/download/espree-4.1.0.tgz?cache=0&sync_timestamp=1571624368510&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fespree%2Fdownload%2Fespree-4.1.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/espree/download/espree-4.1.0.tgz?cache=0&sync_timestamp=1561171239020&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fespree%2Fdownload%2Fespree-4.1.0.tgz",
           "integrity": "sha1-co1UUeD9FWwEOEp62J7VH/VOsl8=",
           "dev": true,
           "requires": {
@@ -12562,7 +12562,7 @@
     },
     "vue-router": {
       "version": "3.0.7",
-      "resolved": "https://registry.npm.taobao.org/vue-router/download/vue-router-3.0.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-router%2Fdownload%2Fvue-router-3.0.7.tgz",
+      "resolved": "https://registry.npm.taobao.org/vue-router/download/vue-router-3.0.7.tgz?cache=0&sync_timestamp=1562164292099&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-router%2Fdownload%2Fvue-router-3.0.7.tgz",
       "integrity": "sha1-s2yhB7SsuP9bxP+CRYQFnCP8uHs="
     },
     "vue-server-renderer": {
@@ -12582,17 +12582,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&sync_timestamp=1566430562325&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz?cache=0&sync_timestamp=1570527339087&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-1.1.3.tgz",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12619,7 +12619,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -12627,7 +12627,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
@@ -12674,7 +12674,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/w3c-hr-time/download/w3c-hr-time-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/w3c-hr-time/download/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "requires": {
         "browser-process-hrtime": "^0.1.2"
@@ -12682,7 +12682,7 @@
     },
     "watchpack": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/watchpack/download/watchpack-1.6.0.tgz?cache=0&sync_timestamp=1571664775955&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwatchpack%2Fdownload%2Fwatchpack-1.6.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/watchpack/download/watchpack-1.6.0.tgz?cache=0&sync_timestamp=1562782917067&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwatchpack%2Fdownload%2Fwatchpack-1.6.0.tgz",
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "requires": {
         "chokidar": "^2.0.2",
@@ -12692,7 +12692,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fanymatch%2Fdownload%2Fanymatch-2.0.0.tgz",
           "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "requires": {
             "micromatch": "^3.1.4",
@@ -12716,7 +12716,7 @@
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.8.tgz?cache=0&sync_timestamp=1572225102486&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchokidar%2Fdownload%2Fchokidar-2.1.8.tgz",
+          "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.8.tgz",
           "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
           "requires": {
             "anymatch": "^2.0.0",
@@ -13257,7 +13257,7 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1571011714883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1562457210009&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
           "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -13267,7 +13267,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -13277,7 +13277,7 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/webidl-conversions/download/webidl-conversions-4.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/webidl-conversions/download/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60="
     },
     "webpack": {
@@ -13334,7 +13334,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1567421597140&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "requires": {
             "ajv": "^6.1.0",
@@ -13412,7 +13412,7 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.4.4.tgz",
+          "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz",
           "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
         }
       }
@@ -13443,12 +13443,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -13458,7 +13458,7 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-log/download/webpack-log-2.0.0.tgz?cache=0&sync_timestamp=1564684394562&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-log%2Fdownload%2Fwebpack-log-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/webpack-log/download/webpack-log-2.0.0.tgz",
       "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
       "requires": {
         "ansi-colors": "^3.0.0",
@@ -13503,7 +13503,7 @@
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/whatwg-encoding/download/whatwg-encoding-1.0.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/whatwg-encoding/download/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "requires": {
         "iconv-lite": "0.4.24"
@@ -13511,12 +13511,12 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/whatwg-mimetype/download/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/whatwg-mimetype/download/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78="
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://registry.npm.taobao.org/whatwg-url/download/whatwg-url-6.5.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/whatwg-url/download/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -13549,7 +13549,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -13565,7 +13565,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -13615,7 +13615,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcolor-convert%2Fdownload%2Fcolor-convert-2.0.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
@@ -13635,7 +13635,7 @@
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/write/download/write-1.0.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/write/download/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "dev": true,
       "requires": {
@@ -13704,7 +13704,7 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/xml-name-validator/download/xml-name-validator-3.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/xml-name-validator/download/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo="
     },
     "xtend": {
@@ -13714,7 +13714,7 @@
     },
     "xxhashjs": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/xxhashjs/download/xxhashjs-0.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/xxhashjs/download/xxhashjs-0.2.2.tgz",
       "integrity": "sha1-imJRVnYhocRqWuIE2gJJx/jKqdg=",
       "requires": {
         "cuint": "^0.2.2"
@@ -13732,7 +13732,7 @@
     },
     "yargs": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-7.1.0.tgz?cache=0&sync_timestamp=1570412076919&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-7.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
@@ -13753,7 +13753,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-regex%2Fdownload%2Fansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
@@ -13775,7 +13775,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -13843,7 +13843,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz?cache=0&sync_timestamp=1569564346247&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg-up%2Fdownload%2Fread-pkg-up-1.0.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -13864,7 +13864,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13890,7 +13890,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-5.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-5.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {

--- a/site/package.json
+++ b/site/package.json
@@ -8,10 +8,10 @@
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint",
-    "dev": "nuxt",
+    "dev": "HOST=0.0.0.0 PORT=3000 nuxt",
     "debug": "node --inspect node_modules/.bin/nuxt",
     "build": "nuxt build",
-    "start": "nuxt start",
+    "start": "HOST=0.0.0.0 PORT=3000 nuxt start --max_old_space_size=3072 --optimize_for_size",
     "generate": "nuxt generate"
   },
   "dependencies": {

--- a/site/pages/user/signin.vue
+++ b/site/pages/user/signin.vue
@@ -62,7 +62,7 @@
 <script>
 import utils from '~/common/utils'
 import GithubLogin from '~/components/GithubLogin'
-import QqLogin from '~/components/QqLogin'
+import QqLogin from '~/components/QQLogin'
 export default {
   components: {
     GithubLogin, QqLogin

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,4 @@
+docker-compose build
+docker-compose down
+docker-compose run --rm start_dependencies
+docker-compose up


### PR DESCRIPTION

### 目的
当前项目get start有点困难, 此PR着重提供docker化方案, 编排使用docker-compose
使得三个服务能够同时一起运行部署, 一键构建

```sh
./up
```

###  特性
- docker启动,无需本地依赖
- 数据库seed支持, 不用手工构建, 参考`init-db.sql`

### 注意事项

容器化的server启动配置, server的数据库host, 要改成和compose的db一致, 比如
```
MySqlUrl: root:@tcp(db:3306)/mlog_db?charset=utf8&parseTime=True&loc=Local  # 数据库链接
```
其他的配置类似.

### 可跟进要点
- [ ] admin的production不知道如何启动, 目前用了dev模式
- [ ] site的Dockerfile的production处理得不干净, 镜像体积还是太大了
- [ ] admin里关于server host的配置, 写死没有配置化, 改成`bbs-go-server`有错误, 原因待查
- [ ] 配置文件删除出git仓库, 只留.example
- [ ] package-lock.json 移出.gitignore




