### PR TITLE
修改后台修改用户密码和角色的bug

### DIFF
--- a/server/controllers/admin/user_controller.go
+++ b/server/controllers/admin/user_controller.go
@@ -91,14 +91,25 @@ func (c *UserController) PostUpdate() *simple.JsonResult {
 	password := simple.FormValue(c.Ctx, "password")
 	nickname := simple.FormValue(c.Ctx, "nickname")
 	email := simple.FormValue(c.Ctx, "email")
-	roles := simple.FormValueStringArray(c.Ctx, "roles")
 	status := simple.FormValueIntDefault(c.Ctx, "status", -1)
+
+	formValues := c.Ctx.FormValues()
+	var rolesKeys []string
+	for k := range formValues {
+		if strings.HasPrefix(k, "roles") {
+			rolesKeys = append(rolesKeys, k)
+		}
+	}
+	roles := make([]string, len(rolesKeys))
+	for i, v := range rolesKeys {
+		roles[i] = simple.FormValue(c.Ctx, v)
+	}
 
 	if len(username) > 0 {
 		t.Username = simple.SqlNullString(username)
 	}
 	if len(password) > 0 {
-		t.Password = simple.EncodePassword(t.Password)
+		t.Password = simple.EncodePassword(password)
 	}
 	if len(nickname) > 0 {
 		t.Nickname = nickname


### PR DESCRIPTION
### 问题概述：
管理员登录后台修改用户信息，会出现密码修改错误和用户角色丢失的问题，经排查是user_controller模块代码bug，
### 具体错误:
- 密码使用的是数据库查询的加密字符串，
- 用户从前端获取 roles 的是数组（roles[0]\roles[1]\roles[X])，原来的代码是获取不到的。
### 修改点：
- 密码值改为前端获取的字符，即t.Password -> password
- 角色值改为遍历 fromValues 获取前缀是 roles 的 key，再通过遍历获取具体的 roles[X]