### PR TITLE
修复后台友链logo显示问题

### DIFF
--- a/site/pages/admin/links/index.vue
+++ b/site/pages/admin/links/index.vue
@@ -44,7 +44,7 @@
       </el-table-column>
       <el-table-column prop="logo" label="Logo" width="60">
         <template slot-scope="scope">
-          <img v-if="scope.row.log" :src="scope.row.logo" class="link-logo" />
+          <img v-if="scope.row.logo" :src="scope.row.logo" class="link-logo" />
           <img v-else src="~/assets/images/net.png" class="link-logo" />
         </template>
       </el-table-column>


### PR DESCRIPTION
### 问题概述：
后台友链 logo 显示不出自定义的 logo

### 具体错误：
vue模板获取 logo 判断错误

### 修改点：
- 修改判断 row.log -> row.logo
