### PR TITLE
修改文章页标签错误&修复动态xss注入

### DIFF
--- a/server/controllers/render/render.go
+++ b/server/controllers/render/render.go
@@ -398,13 +398,14 @@ func _buildComment(comment *model.Comment, buildQuote bool) *model.CommentRespon
 	}
 
 	ret := &model.CommentResponse{
-		CommentId:  comment.Id,
-		User:       BuildUserDefaultIfNull(comment.UserId),
-		EntityType: comment.EntityType,
-		EntityId:   comment.EntityId,
-		QuoteId:    comment.QuoteId,
-		Status:     comment.Status,
-		CreateTime: comment.CreateTime,
+		CommentId:   comment.Id,
+		User:        BuildUserDefaultIfNull(comment.UserId),
+		EntityType:  comment.EntityType,
+		EntityId:    comment.EntityId,
+		QuoteId:     comment.QuoteId,
+		Status:      comment.Status,
+		ContentType: comment.ContentType,
+		CreateTime:  comment.CreateTime,
 	}
 
 	if comment.ContentType == model.ContentTypeMarkdown {

--- a/server/model/response.go
+++ b/server/model/response.go
@@ -124,6 +124,7 @@ type CommentResponse struct {
 	Quote        *CommentResponse `json:"quote"`
 	QuoteContent string           `json:"quoteContent"`
 	Status       int              `json:"status"`
+	ContentType  string           `json:"content_type"`
 	CreateTime   int64            `json:"createTime"`
 }
 

--- a/site/components/CommentList.vue
+++ b/site/components/CommentList.vue
@@ -64,13 +64,26 @@
               </div>
               <div
                 v-lazy-container="{ selector: 'img' }"
+                v-if="comment.content_type === 'markdown'"
                 v-html="comment.quote.content"
+                itemprop="text"
+              />
+              <div
+                v-lazy-container="{ selector: 'img' }"
+                v-else-if="comment.content_type === 'text'"
+                v-text="comment.quote.content"
                 itemprop="text"
               />
             </blockquote>
             <p
               v-lazy-container="{ selector: 'img' }"
+              v-if="comment.content_type === 'markdown'"
               v-html="comment.content"
+            />
+            <p
+              v-lazy-container="{ selector: 'img' }"
+              v-else-if="comment.content_type === 'text'"
+              v-text="comment.content"
             />
           </div>
         </li>

--- a/site/pages/article/_id.vue
+++ b/site/pages/article/_id.vue
@@ -45,7 +45,7 @@
                       tag.tagName
                     }}</a>
                   </span>
-                </div>
+                </span>
 
                 <div class="article-tool">
                   <span v-if="isOwner">


### PR DESCRIPTION
问题描述：
1. 文章详情页面 标签错误
2. 动态回复xss注入

修改点：
1. 文章详情页面标签
2. 评论列表增加评论类型判断 text\markdown
3. 评论列表接口增加content_type字段