### PR TITLE
当使用本地存储图片资源时，增加文件服务器

### DIFF
--- a/server/app/iris.go
+++ b/server/app/iris.go
@@ -102,6 +102,13 @@ func InitIris() {
 		}
 	})
 
+	//if uploader is set to local, then we should start a static file server
+	if config.Conf.Uploader.Enable == "local"{
+		fileServer := iris.FileServer(config.Conf.Uploader.Local.Path)
+		h := iris.StripPrefix("", fileServer)
+		app.Get(  "/images/{f:path}", h)
+	}
+
 	server := &http.Server{Addr: ":" + config.Conf.Port}
 	handleSignal(server)
 	err := app.Run(iris.Server(server), iris.WithConfiguration(iris.Configuration{


### PR DESCRIPTION
增加本地文件服务，否则当时候本地存储时无法访问图片资源