### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/site/src/composables/utils.js
+++ b/site/src/composables/utils.js
@@ -51,7 +51,7 @@ export function useLinkTo(path) {
 }
 
 export function useToSignIn(redirect) {
-  if (!redirect && process.client) {
+  if (!redirect && import.meta.client) {
     redirect = window.location.pathname;
   }
   useLinkTo("/user/signin?redirect=" + encodeURIComponent(redirect));

--- a/site/src/middleware/fetch.global.ts
+++ b/site/src/middleware/fetch.global.ts
@@ -12,7 +12,7 @@ export default defineNuxtRouteMiddleware(async () => {
     const nuxtApp = useNuxtApp()
 
     // 服务端渲染，或者客服端渲染
-    if (process.server || (process.client && !nuxtApp.isHydrating)) {
+    if (import.meta.server || (import.meta.client && !nuxtApp.isHydrating)) {
         await load()
     }
 


### PR DESCRIPTION
This is a very early PR to make this app compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.
