### PR TITLE
fix: 修复发布评论时报错

### DIFF
--- a/site/src/components/CommentList.vue
+++ b/site/src/components/CommentList.vue
@@ -134,7 +134,9 @@ export default {
   },
   methods: {
     append(data) {
-      this.$refs.commentsLoadMore.unshiftResults(data);
+      this.$nextTick(() => {
+        this.$refs.commentsLoadMore.unshiftResults(data);
+      }
     },
     async like(comment) {
       try {


### PR DESCRIPTION
修复发布评论时报错：
```
Uncaught (in promise) TypeError: this.$refs.commentsLoadMore.appendResults is not a function
```
<img width="460" alt="image" src="https://github.com/mlogclub/bbs-go/assets/21010051/4c436b9b-9d33-4769-b10e-89bdf7ced61c">
