### PR TITLE
fix install PostgreSQL option copy

### DIFF
--- a/web/components/install/install-wizard.tsx
+++ b/web/components/install/install-wizard.tsx
@@ -42,6 +42,12 @@ function defaultBaseURL() {
   return typeof window === "undefined" ? "/" : window.location.origin
 }
 
+function defaultPortForDbType(type: DbType) {
+  if (type === "postgresql") return "5432"
+  if (type === "mysql") return "3306"
+  return ""
+}
+
 export function InstallWizard({
   dockerBuiltinMysql = false,
 }: {
@@ -109,6 +115,12 @@ export function InstallWizard({
     if (dockerBuiltinMysql) return
     setDbConfig((current) => {
       const next = { ...current, ...values }
+      if (values.type && values.type !== current.type) {
+        const port = defaultPortForDbType(values.type)
+        if (port) {
+          next.port = port
+        }
+      }
       if (
         next.type === "sqlite" ||
         (next.host && next.port && next.database && next.username)
@@ -444,7 +456,11 @@ export function InstallWizard({
                       label={t("pages.install.database.port")}
                       id="db-port"
                       value={dockerBuiltinMysql ? "3306" : dbConfig.port}
-                      placeholder={t("pages.install.database.portPlaceholder")}
+                      placeholder={
+                        dockerBuiltinMysql
+                          ? "3306"
+                          : defaultPortForDbType(effectiveDbType)
+                      }
                       onChange={(port) => updateDbConfig({ port })}
                       disabled={dockerBuiltinMysql}
                     />

--- a/web/lib/i18n/messages/en-US.ts
+++ b/web/lib/i18n/messages/en-US.ts
@@ -1519,7 +1519,8 @@ const enUS = {
           "Welcome to BBS-GO, a lightweight community and Q&A platform built with Go. Before you start, make sure you have:",
         requirements: {
           title: "Installation Requirements",
-          mysql: "MySQL (5.7+) or SQLite. MySQL is recommended for production.",
+          mysql:
+            "MySQL (5.7+), PostgreSQL, or SQLite. MySQL or PostgreSQL is recommended for production.",
           site: "A community name and description",
           admin: "An administrator username and password",
         },
@@ -1546,7 +1547,7 @@ const enUS = {
         password: "Password",
         passwordPlaceholder: "Database password",
         sqliteWarning:
-          "SQLite is suitable for local testing or small deployments. MySQL is recommended for production.",
+          "SQLite is suitable for local testing or small deployments. MySQL or PostgreSQL is recommended for production.",
         sqliteAutoPath:
           "The SQLite database file path will be handled by the server.",
         dockerBuiltinMysqlNotice:

--- a/web/lib/i18n/messages/zh-CN.ts
+++ b/web/lib/i18n/messages/zh-CN.ts
@@ -1487,7 +1487,8 @@ const zhCN = {
           "欢迎使用 BBS-GO，这是一个基于Go语言开发的社区系统。在开始安装前，请确保您已经准备好以下内容：",
         requirements: {
           title: "安装要求",
-          mysql: "MySQL（5.7+）或 SQLite 数据库（生产环境建议使用 MySQL）",
+          mysql:
+            "MySQL（5.7+）、PostgreSQL 或 SQLite 数据库（生产环境建议使用 MySQL 或 PostgreSQL）",
           site: "已经规划好社区名称和描述",
           admin: "已准备好管理员账号和密码",
         },
@@ -1513,7 +1514,7 @@ const zhCN = {
         password: "密码",
         passwordPlaceholder: "数据库密码",
         sqliteWarning:
-          "SQLite 适合本地测试或小规模部署，生产环境建议使用 MySQL。",
+          "SQLite 适合本地测试或小规模部署，生产环境建议使用 MySQL 或 PostgreSQL。",
         sqliteAutoPath: "SQLite 数据库文件路径将由服务端自动处理。",
         dockerBuiltinMysqlNotice:
           "当前使用 Docker 内置 MySQL 部署，数据库连接由系统自动配置，安装时只需继续下一步。",


### PR DESCRIPTION
## Summary

Fixes #288.

Updates the install wizard PostgreSQL option details:

- Set the default database port to 5432 when switching to PostgreSQL.
- Keep MySQL switching on the 3306 default.
- Update English and Chinese install requirements to list MySQL, PostgreSQL, and SQLite.
- Update the SQLite production warning to recommend MySQL or PostgreSQL.

## Validation

- pnpm --dir web typecheck
- pnpm --dir web lint