### PR TITLE
fix builtin PostgreSQL install path

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -22,10 +22,19 @@ It combines discussions, Q&A workflows, articles, comments, notifications, moder
 
 ## Quick Start with Docker Compose
 
-bbs-go provides an official Docker image and Docker Compose deployment with built-in MySQL support.
+bbs-go provides an official Docker image and Docker Compose deployments with built-in MySQL or PostgreSQL support.
+
+MySQL:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mlogclub/bbs-go/master/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+```
+
+PostgreSQL:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mlogclub/bbs-go/master/docker-compose.postgresql.yml -o docker-compose.yml
 docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@
 - 后台: https://bbs.bbs-go.com/admin
 - 后台账号密码: 联系我们获取，联系方式：<https://bbs-go.com/docs/contact>
 
+## Docker Compose 快速开始
+
+bbs-go 提供官方 Docker 镜像，并提供内置 MySQL 或 PostgreSQL 的 Docker Compose 部署方式。
+
+MySQL：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mlogclub/bbs-go/master/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+```
+
+PostgreSQL：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mlogclub/bbs-go/master/docker-compose.postgresql.yml -o docker-compose.yml
+docker compose up -d
+```
+
+启动后访问：
+
+- 前台：<http://localhost:3000>
+- 后台：<http://localhost:3000/dashboard>
+- 安装向导：<http://localhost:3000/install>
+
 ## 为什么选择 bbs-go
 
 - **开箱可用**：论坛、问答、文章、评论、点赞收藏、关注消息等核心社区能力可直接使用。

--- a/docker-compose.postgresql.yml
+++ b/docker-compose.postgresql.yml
@@ -1,0 +1,52 @@
+x-builtin-postgresql-env: &builtin-postgresql-env
+  POSTGRES_DB: ${BBSGO_DOCKER_POSTGRESQL_DATABASE:-bbsgo}
+  POSTGRES_USER: ${BBSGO_DOCKER_POSTGRESQL_USER:-bbsgo}
+  POSTGRES_PASSWORD: ${BBSGO_DOCKER_POSTGRESQL_PASSWORD:-bbsgo_password}
+
+services:
+  postgresql:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      <<: *builtin-postgresql-env
+      TZ: Asia/Shanghai
+    volumes:
+      - postgresql-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  bbs-go:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    image: mlogclub/bbs-go:${BBSGO_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    volumes:
+      # bbs-go.yaml is stored in /app/data. Keep runtime files on the host
+      # so deleting/recreating the container does not reset the install config.
+      - ./docker-data-postgresql/data:/app/data
+      - ./docker-data-postgresql/logs:/app/logs
+      - ./docker-data-postgresql/uploads:/app/res/uploads
+    ports:
+      - "3000:3000"
+    environment:
+      BBSGO_ENV: prod
+      NODE_ENV: production
+      PORT: 3000
+      BBSGO_SERVER_URL: http://127.0.0.1:8082
+      BBSGO_INSTALL_DOCKER_BUILTIN_POSTGRESQL: "true"
+      BBSGO_DOCKER_BUILTIN_POSTGRESQL_HOST: postgresql
+      BBSGO_DOCKER_BUILTIN_POSTGRESQL_PORT: "5432"
+      BBSGO_DOCKER_BUILTIN_POSTGRESQL_DATABASE: ${BBSGO_DOCKER_POSTGRESQL_DATABASE:-bbsgo}
+      BBSGO_DOCKER_BUILTIN_POSTGRESQL_USERNAME: ${BBSGO_DOCKER_POSTGRESQL_USER:-bbsgo}
+      BBSGO_DOCKER_BUILTIN_POSTGRESQL_PASSWORD: ${BBSGO_DOCKER_POSTGRESQL_PASSWORD:-bbsgo_password}
+      TZ: Asia/Shanghai
+
+volumes:
+  postgresql-data:

--- a/internal/handlers/api/install_handlers.go
+++ b/internal/handlers/api/install_handlers.go
@@ -18,9 +18,10 @@ func InstallStatus(ctx *gin.Context) {
 
 	cfg := config.Instance
 	ginx.WriteJSON(ctx, map[string]any{
-		"installed":          cfg.Installed,
-		"dockerBuiltinMysql": install.IsDockerBuiltinMySQLInstall(),
-		"dbType":             cfg.DB.Type,
+		"installed":           cfg.Installed,
+		"dockerBuiltinMysql":  install.IsDockerBuiltinMySQLInstall(),
+		"dockerBuiltinDbType": install.DockerBuiltinDBType(),
+		"dbType":              cfg.DB.Type,
 	})
 
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -101,9 +101,9 @@ func (r DbConfigReq) GetConnStr() string {
 
 func TestDbConnection(ctx context.Context, req DbConfigReq) error {
 	var dsn string
-	if IsDockerBuiltinMySQLInstall() {
+	if builtinDBType := DockerBuiltinDBType(); builtinDBType != "" {
 		req = DbConfigReq{
-			Type: config.DbTypeMySQL,
+			Type: builtinDBType,
 		}
 		dsn = config.Instance.DB.Url
 	}
@@ -183,9 +183,9 @@ func Install(req InstallReq) error {
 	installMx.Lock()
 	defer installMx.Unlock()
 
-	if IsDockerBuiltinMySQLInstall() {
+	if builtinDBType := DockerBuiltinDBType(); builtinDBType != "" {
 		req.DbConfig = DbConfigReq{
-			Type: config.DbTypeMySQL,
+			Type: builtinDBType,
 		}
 	}
 	// 传入 context
@@ -217,7 +217,7 @@ func WriteConfig(req InstallReq) error {
 	cfg := config.Instance
 	cfg.Language = req.Language
 	cfg.IDCodec.Key = idcodec.GenerateRandomKey()
-	if !IsDockerBuiltinMySQLInstall() {
+	if !IsDockerBuiltinDBInstall() {
 		if req.DbConfig.Type == "" {
 			req.DbConfig.Type = config.DbTypeMySQL
 		}
@@ -465,6 +465,20 @@ func IsDockerBuiltinPostgreSQLInstall() bool {
 	}
 }
 
+func IsDockerBuiltinDBInstall() bool {
+	return DockerBuiltinDBType() != ""
+}
+
+func DockerBuiltinDBType() string {
+	if IsDockerBuiltinPostgreSQLInstall() {
+		return config.DbTypePostgreSQL
+	}
+	if IsDockerBuiltinMySQLInstall() {
+		return config.DbTypeMySQL
+	}
+	return ""
+}
+
 func ApplyDockerBuiltinMySQLConfig() {
 	if !IsDockerBuiltinMySQLInstall() {
 		return
@@ -497,13 +511,18 @@ func ApplyDockerBuiltinPostgreSQLConfig() {
 }
 
 func WriteRuntimeConfig(cfg *config.Config) error {
-	if !IsDockerBuiltinMySQLInstall() {
-		return config.WriteConfig(cfg)
+	return config.WriteConfig(runtimeConfigForWrite(cfg))
+}
+
+func runtimeConfigForWrite(cfg *config.Config) *config.Config {
+	builtinDBType := DockerBuiltinDBType()
+	if builtinDBType == "" {
+		return cfg
 	}
 	persisted := *cfg
-	persisted.DB.Type = config.DbTypeMySQL
+	persisted.DB.Type = builtinDBType
 	persisted.DB.Url = ""
-	return config.WriteConfig(&persisted)
+	return &persisted
 }
 
 func dockerBuiltinMySQLEnv(key string, fallback string) string {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bbs-go/internal/pkg/config"
 	"testing"
 
 	"gorm.io/gorm/logger"
@@ -28,4 +29,112 @@ func TestResolveGormLogLevel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDockerBuiltinDBType(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "")
+
+		if got := DockerBuiltinDBType(); got != "" {
+			t.Fatalf("expected empty builtin db type, got %q", got)
+		}
+		if IsDockerBuiltinDBInstall() {
+			t.Fatal("expected builtin db install to be disabled")
+		}
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "true")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "")
+
+		if got := DockerBuiltinDBType(); got != config.DbTypeMySQL {
+			t.Fatalf("expected %q, got %q", config.DbTypeMySQL, got)
+		}
+	})
+
+	t.Run("postgresql takes precedence", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "true")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "true")
+
+		if got := DockerBuiltinDBType(); got != config.DbTypePostgreSQL {
+			t.Fatalf("expected %q, got %q", config.DbTypePostgreSQL, got)
+		}
+	})
+}
+
+func TestApplyDockerBuiltinPostgreSQLConfig(t *testing.T) {
+	previousConfig := config.Instance
+	t.Cleanup(func() {
+		config.Instance = previousConfig
+	})
+
+	t.Setenv(DockerBuiltinPostgreSQLEnv, "true")
+	t.Setenv(DockerBuiltinPostgreSQLHostEnv, "pg")
+	t.Setenv(DockerBuiltinPostgreSQLPortEnv, "15432")
+	t.Setenv(DockerBuiltinPostgreSQLDatabaseEnv, "bbsgo_test")
+	t.Setenv(DockerBuiltinPostgreSQLUsernameEnv, "bbsgo_user")
+	t.Setenv(DockerBuiltinPostgreSQLPasswordEnv, "bbsgo_secret")
+
+	config.Instance = &config.Config{}
+	ApplyDockerBuiltinPostgreSQLConfig()
+
+	if got := config.Instance.DB.Type; got != config.DbTypePostgreSQL {
+		t.Fatalf("expected db type %q, got %q", config.DbTypePostgreSQL, got)
+	}
+	wantDSN := "host=pg port=15432 user=bbsgo_user password=bbsgo_secret dbname=bbsgo_test sslmode=disable"
+	if got := config.Instance.DB.Url; got != wantDSN {
+		t.Fatalf("expected dsn %q, got %q", wantDSN, got)
+	}
+}
+
+func TestRuntimeConfigForWriteClearsBuiltinDBUrl(t *testing.T) {
+	cfg := &config.Config{
+		DB: config.DBConfig{
+			Type: config.DbTypePostgreSQL,
+			Url:  "host=pg port=5432 user=bbsgo password=secret dbname=bbsgo sslmode=disable",
+		},
+	}
+
+	t.Run("postgresql", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "true")
+
+		got := runtimeConfigForWrite(cfg)
+		if got == cfg {
+			t.Fatal("expected builtin runtime config to be copied before write")
+		}
+		if got.DB.Type != config.DbTypePostgreSQL {
+			t.Fatalf("expected db type %q, got %q", config.DbTypePostgreSQL, got.DB.Type)
+		}
+		if got.DB.Url != "" {
+			t.Fatalf("expected persisted db url to be empty, got %q", got.DB.Url)
+		}
+		if cfg.DB.Url == "" {
+			t.Fatal("expected runtime config db url to stay available")
+		}
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "true")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "")
+
+		got := runtimeConfigForWrite(cfg)
+		if got.DB.Type != config.DbTypeMySQL {
+			t.Fatalf("expected db type %q, got %q", config.DbTypeMySQL, got.DB.Type)
+		}
+		if got.DB.Url != "" {
+			t.Fatalf("expected persisted db url to be empty, got %q", got.DB.Url)
+		}
+	})
+
+	t.Run("none", func(t *testing.T) {
+		t.Setenv(DockerBuiltinMySQLEnv, "")
+		t.Setenv(DockerBuiltinPostgreSQLEnv, "")
+
+		got := runtimeConfigForWrite(cfg)
+		if got != cfg {
+			t.Fatal("expected non-builtin runtime config to be written directly")
+		}
+	})
 }

--- a/web/app/routes/install.tsx
+++ b/web/app/routes/install.tsx
@@ -1,6 +1,6 @@
 import { Navigate } from "react-router"
 
-import { InstallWizard } from "@/components/install/install-wizard"
+import { InstallWizard, type DbType } from "@/components/install/install-wizard"
 import { apiFetch } from "@/lib/api/client"
 import { useI18n } from "@/lib/i18n/provider"
 import { noindexRouteMeta } from "@/lib/seo"
@@ -21,14 +21,13 @@ export default function InstallRoute() {
   useDocumentTitle(t("pages.install.title"))
   const { data, loading } = useClientData<{
     installed?: boolean
+    dockerBuiltinDbType?: DbType
     dockerBuiltinMysql?: boolean
     dbType?: string
-  }>(
-    "install-status",
-    () =>
-      apiFetch<{ installed?: boolean }>("/api/install/status").catch(() => ({
-        installed: true,
-      }))
+  }>("install-status", () =>
+    apiFetch<{ installed?: boolean }>("/api/install/status").catch(() => ({
+      installed: true,
+    }))
   )
 
   if (loading) {
@@ -40,5 +39,12 @@ export default function InstallRoute() {
   }
   if (data?.installed) return <Navigate to="/" replace />
 
-  return <InstallWizard dockerBuiltinMysql={Boolean(data?.dockerBuiltinMysql)} />
+  return (
+    <InstallWizard
+      dockerBuiltinDbType={
+        data?.dockerBuiltinDbType ||
+        (data?.dockerBuiltinMysql ? "mysql" : undefined)
+      }
+    />
+  )
 }

--- a/web/components/install/install-wizard.tsx
+++ b/web/components/install/install-wizard.tsx
@@ -25,7 +25,7 @@ import { ApiError, apiFetch } from "@/lib/api/client"
 import { createT, type Locale } from "@/lib/i18n"
 
 type Step = "welcome" | "database" | "site" | "admin" | "install" | "complete"
-type DbType = "mysql" | "postgresql" | "sqlite"
+export type DbType = "mysql" | "postgresql" | "sqlite"
 
 const avatarCount = 128
 const avatarBase = "/res/images/avatars"
@@ -48,10 +48,22 @@ function defaultPortForDbType(type: DbType) {
   return ""
 }
 
+function defaultHostForDbType(type: DbType) {
+  if (type === "postgresql") return "postgresql"
+  if (type === "mysql") return "mysql"
+  return ""
+}
+
+function dbTypeLabel(type: DbType) {
+  if (type === "postgresql") return "PostgreSQL"
+  if (type === "mysql") return "MySQL"
+  return "SQLite"
+}
+
 export function InstallWizard({
-  dockerBuiltinMysql = false,
+  dockerBuiltinDbType,
 }: {
-  dockerBuiltinMysql?: boolean
+  dockerBuiltinDbType?: DbType
 }) {
   const [step, setStep] = React.useState<Step>("welcome")
   const [language, setLanguage] = React.useState<Locale>("en-US")
@@ -99,9 +111,10 @@ export function InstallWizard({
   ]
   const currentStepIndex = steps.findIndex((item) => item.key === step)
   const pageBlocking = testingConnection || installing
-  const effectiveDbType: DbType = dockerBuiltinMysql ? "mysql" : dbConfig.type
+  const dockerBuiltinDb = Boolean(dockerBuiltinDbType)
+  const effectiveDbType: DbType = dockerBuiltinDbType || dbConfig.type
   const isDbFormValid =
-    dockerBuiltinMysql ||
+    dockerBuiltinDb ||
     effectiveDbType === "sqlite" ||
     Boolean(
       dbConfig.host && dbConfig.port && dbConfig.database && dbConfig.username
@@ -112,7 +125,7 @@ export function InstallWizard({
     ) && adminInfo.password === adminInfo.passwordConfirm
 
   function updateDbConfig(values: Partial<typeof dbConfig>) {
-    if (dockerBuiltinMysql) return
+    if (dockerBuiltinDb) return
     setDbConfig((current) => {
       const next = { ...current, ...values }
       if (values.type && values.type !== current.type) {
@@ -133,7 +146,7 @@ export function InstallWizard({
   }
 
   function validateDbForm() {
-    if (dockerBuiltinMysql) {
+    if (dockerBuiltinDb) {
       return true
     }
     if (effectiveDbType === "sqlite") {
@@ -208,8 +221,10 @@ export function InstallWizard({
         },
       })
       setDbSuccess(
-        dockerBuiltinMysql
-          ? t("pages.install.database.dockerBuiltinMysqlConnectSuccess")
+        dockerBuiltinDb
+          ? t("pages.install.database.dockerBuiltinConnectSuccess", {
+              type: dbTypeLabel(effectiveDbType),
+            })
           : t("pages.install.database.connectSuccess")
       )
       if (nextStep) {
@@ -408,35 +423,38 @@ export function InstallWizard({
                     {t("pages.install.database.type")}
                   </RequiredLabel>
                   <div className="flex items-center space-x-3">
-                    {(["mysql", "postgresql", "sqlite"] as const).map((type) => (
-                      <Button
-                        key={type}
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className={
-                          effectiveDbType === type
-                            ? "bg-primary text-white hover:bg-primary/90 hover:text-white"
-                            : ""
-                        }
-                        disabled={dockerBuiltinMysql}
-                        onClick={() => updateDbConfig({ type })}
-                      >
-                        {type === "mysql" ? "MySQL" : type === "postgresql" ? "PostgreSQL" : "SQLite"}
-                      </Button>
-                    ))}
+                    {(["mysql", "postgresql", "sqlite"] as const).map(
+                      (type) => (
+                        <Button
+                          key={type}
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className={
+                            effectiveDbType === type
+                              ? "bg-primary text-white hover:bg-primary/90 hover:text-white"
+                              : ""
+                          }
+                          disabled={dockerBuiltinDb}
+                          onClick={() => updateDbConfig({ type })}
+                        >
+                          {dbTypeLabel(type)}
+                        </Button>
+                      )
+                    )}
                   </div>
                 </div>
-                {(effectiveDbType === "mysql" || effectiveDbType === "postgresql") ? (
+                {effectiveDbType === "mysql" ||
+                effectiveDbType === "postgresql" ? (
                   <>
-                    {dockerBuiltinMysql ? (
+                    {dockerBuiltinDb ? (
                       <Alert className="border-blue-200 bg-blue-50 md:col-span-2">
                         <div className="flex gap-2">
                           <Database className="mt-1 h-4 w-4 text-blue-700" />
                           <AlertDescription className="text-blue-800">
-                            {t(
-                              "pages.install.database.dockerBuiltinMysqlNotice"
-                            )}
+                            {t("pages.install.database.dockerBuiltinNotice", {
+                              type: dbTypeLabel(effectiveDbType),
+                            })}
                           </AlertDescription>
                         </div>
                       </Alert>
@@ -445,56 +463,60 @@ export function InstallWizard({
                       required
                       label={t("pages.install.database.host")}
                       id="db-host"
-                      value={dockerBuiltinMysql ? "mysql" : dbConfig.host}
+                      value={
+                        dockerBuiltinDb
+                          ? defaultHostForDbType(effectiveDbType)
+                          : dbConfig.host
+                      }
                       placeholder={t("pages.install.database.hostPlaceholder")}
                       onChange={(host) => updateDbConfig({ host })}
                       help={t("pages.install.database.hostHelp")}
-                      disabled={dockerBuiltinMysql}
+                      disabled={dockerBuiltinDb}
                     />
                     <FormField
                       required
                       label={t("pages.install.database.port")}
                       id="db-port"
-                      value={dockerBuiltinMysql ? "3306" : dbConfig.port}
-                      placeholder={
-                        dockerBuiltinMysql
-                          ? "3306"
-                          : defaultPortForDbType(effectiveDbType)
+                      value={
+                        dockerBuiltinDb
+                          ? defaultPortForDbType(effectiveDbType)
+                          : dbConfig.port
                       }
+                      placeholder={defaultPortForDbType(effectiveDbType)}
                       onChange={(port) => updateDbConfig({ port })}
-                      disabled={dockerBuiltinMysql}
+                      disabled={dockerBuiltinDb}
                     />
                     <FormField
                       required
                       label={t("pages.install.database.name")}
                       id="db-name"
-                      value={dockerBuiltinMysql ? "bbsgo" : dbConfig.database}
+                      value={dockerBuiltinDb ? "bbsgo" : dbConfig.database}
                       placeholder={t("pages.install.database.namePlaceholder")}
                       onChange={(database) => updateDbConfig({ database })}
-                      disabled={dockerBuiltinMysql}
+                      disabled={dockerBuiltinDb}
                     />
                     <FormField
                       required
                       label={t("pages.install.database.username")}
                       id="db-user"
-                      value={dockerBuiltinMysql ? "bbsgo" : dbConfig.username}
+                      value={dockerBuiltinDb ? "bbsgo" : dbConfig.username}
                       placeholder={t(
                         "pages.install.database.usernamePlaceholder"
                       )}
                       onChange={(username) => updateDbConfig({ username })}
-                      disabled={dockerBuiltinMysql}
+                      disabled={dockerBuiltinDb}
                     />
                     <FormField
                       className="md:col-span-2"
                       type="password"
                       label={t("pages.install.database.password")}
                       id="db-password"
-                      value={dockerBuiltinMysql ? "********" : dbConfig.password}
+                      value={dockerBuiltinDb ? "********" : dbConfig.password}
                       placeholder={t(
                         "pages.install.database.passwordPlaceholder"
                       )}
                       onChange={(password) => updateDbConfig({ password })}
-                      disabled={dockerBuiltinMysql}
+                      disabled={dockerBuiltinDb}
                     />
                   </>
                 ) : (

--- a/web/lib/i18n/messages/en-US.ts
+++ b/web/lib/i18n/messages/en-US.ts
@@ -1552,12 +1552,16 @@ const enUS = {
           "The SQLite database file path will be handled by the server.",
         dockerBuiltinMysqlNotice:
           "Docker built-in MySQL is enabled. The database connection is configured automatically, so continue to the next step.",
+        dockerBuiltinNotice:
+          "Docker built-in {type} is enabled. The database connection is configured automatically, so continue to the next step.",
         validationError: "Please complete the database connection information.",
         testing: "Testing...",
         testConnection: "Test connection",
         connectSuccess: "Database connection successful",
         dockerBuiltinMysqlConnectSuccess:
           "Docker built-in MySQL connection successful",
+        dockerBuiltinConnectSuccess:
+          "Docker built-in {type} connection successful",
         connectFailed: "Database connection failed",
       },
       site: {

--- a/web/lib/i18n/messages/zh-CN.ts
+++ b/web/lib/i18n/messages/zh-CN.ts
@@ -1518,11 +1518,14 @@ const zhCN = {
         sqliteAutoPath: "SQLite 数据库文件路径将由服务端自动处理。",
         dockerBuiltinMysqlNotice:
           "当前使用 Docker 内置 MySQL 部署，数据库连接由系统自动配置，安装时只需继续下一步。",
+        dockerBuiltinNotice:
+          "当前使用 Docker 内置 {type} 部署，数据库连接由系统自动配置，安装时只需继续下一步。",
         validationError: "请完整填写数据库连接信息。",
         testing: "测试中...",
         testConnection: "测试连接",
         connectSuccess: "数据库连接成功",
         dockerBuiltinMysqlConnectSuccess: "Docker 内置 MySQL 连接成功",
+        dockerBuiltinConnectSuccess: "Docker 内置 {type} 连接成功",
         connectFailed: "数据库连接失败",
       },
       site: {


### PR DESCRIPTION
## Summary

Fixes #286.

Completes the Docker built-in PostgreSQL install path:

- Expose dockerBuiltinDbType from the install status API while preserving dockerBuiltinMysql compatibility.
- Route install/test/config persistence through a generic built-in DB type helper.
- Keep runtime DB URLs available in memory but persist an empty URL for built-in MySQL and PostgreSQL configs.
- Lock the install wizard for built-in MySQL or PostgreSQL and show the matching host, port, notice, and success copy.
- Add docker-compose.postgresql.yml with a built-in PostgreSQL service wired to the new environment variables.
- Document MySQL and PostgreSQL Docker Compose quick starts in both READMEs.

## Validation

- go test ./internal/install ./internal/handlers/api
- go test ./...
- pnpm --dir web typecheck
- pnpm --dir web lint
- ruby -e 'require "yaml"; YAML.load_file("docker-compose.postgresql.yml")'\n\nNote: docker compose config was not run because Docker is not installed in this local environment.