### PR TITLE
fix PostgreSQL DSN escaping

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,12 +93,30 @@ func (r DbConfigReq) GetConnStr() string {
 	case config.DbTypeMySQL:
 		return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&multiStatements=true&loc=Local", r.Username, r.Password, r.Host, r.Port, r.Database)
 	case config.DbTypePostgreSQL:
-		return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", r.Host, r.Port, r.Username, r.Password, r.Database)
+		return buildPostgreSQLDSN(r)
 	case config.DbTypeSQLite:
 		return buildSqliteDSN()
 	default:
 		return ""
 	}
+}
+
+func buildPostgreSQLDSN(r DbConfigReq) string {
+	host := r.Host
+	if r.Port != "" {
+		host = net.JoinHostPort(r.Host, r.Port)
+	}
+
+	dsn := url.URL{
+		Scheme: "postgres",
+		Host:   host,
+		Path:   "/" + r.Database,
+		User:   url.UserPassword(r.Username, r.Password),
+	}
+	query := dsn.Query()
+	query.Set("sslmode", "disable")
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
 }
 
 func TestDbConnection(ctx context.Context, req DbConfigReq) error {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bbs-go/internal/pkg/config"
+	"net/url"
 	"testing"
 
 	"gorm.io/gorm/logger"
@@ -63,6 +64,70 @@ func TestDockerBuiltinDBType(t *testing.T) {
 	})
 }
 
+func TestDbConfigReqGetConnStrPostgreSQLEscapesValues(t *testing.T) {
+	req := DbConfigReq{
+		Type:     config.DbTypePostgreSQL,
+		Host:     "localhost",
+		Port:     "5432",
+		Database: "bbs go",
+		Username: "bbs user",
+		Password: `pa ss'word\`,
+	}
+
+	dsn := req.GetConnStr()
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("expected valid postgresql dsn, got %q: %v", dsn, err)
+	}
+	if parsed.Scheme != "postgres" {
+		t.Fatalf("expected postgres scheme, got %q", parsed.Scheme)
+	}
+	if parsed.Hostname() != req.Host {
+		t.Fatalf("expected host %q, got %q", req.Host, parsed.Hostname())
+	}
+	if parsed.Port() != req.Port {
+		t.Fatalf("expected port %q, got %q", req.Port, parsed.Port())
+	}
+	if parsed.User.Username() != req.Username {
+		t.Fatalf("expected username %q, got %q", req.Username, parsed.User.Username())
+	}
+	password, ok := parsed.User.Password()
+	if !ok {
+		t.Fatal("expected password in postgresql dsn")
+	}
+	if password != req.Password {
+		t.Fatalf("expected password %q, got %q", req.Password, password)
+	}
+	if parsed.Path != "/"+req.Database {
+		t.Fatalf("expected database path %q, got %q", "/"+req.Database, parsed.Path)
+	}
+	if parsed.Query().Get("sslmode") != "disable" {
+		t.Fatalf("expected sslmode=disable, got query %q", parsed.RawQuery)
+	}
+}
+
+func TestDbConfigReqGetConnStrPostgreSQLIPv6Host(t *testing.T) {
+	req := DbConfigReq{
+		Type:     config.DbTypePostgreSQL,
+		Host:     "::1",
+		Port:     "5432",
+		Database: "bbsgo",
+		Username: "bbsgo",
+		Password: "secret",
+	}
+
+	parsed, err := url.Parse(req.GetConnStr())
+	if err != nil {
+		t.Fatalf("expected valid postgresql dsn: %v", err)
+	}
+	if parsed.Hostname() != req.Host {
+		t.Fatalf("expected host %q, got %q", req.Host, parsed.Hostname())
+	}
+	if parsed.Port() != req.Port {
+		t.Fatalf("expected port %q, got %q", req.Port, parsed.Port())
+	}
+}
+
 func TestApplyDockerBuiltinPostgreSQLConfig(t *testing.T) {
 	previousConfig := config.Instance
 	t.Cleanup(func() {
@@ -82,7 +147,7 @@ func TestApplyDockerBuiltinPostgreSQLConfig(t *testing.T) {
 	if got := config.Instance.DB.Type; got != config.DbTypePostgreSQL {
 		t.Fatalf("expected db type %q, got %q", config.DbTypePostgreSQL, got)
 	}
-	wantDSN := "host=pg port=15432 user=bbsgo_user password=bbsgo_secret dbname=bbsgo_test sslmode=disable"
+	wantDSN := "postgres://bbsgo_user:bbsgo_secret@pg:15432/bbsgo_test?sslmode=disable"
 	if got := config.Instance.DB.Url; got != wantDSN {
 		t.Fatalf("expected dsn %q, got %q", wantDSN, got)
 	}


### PR DESCRIPTION
## Summary
- build PostgreSQL install DSNs using URL encoding instead of keyword/value string concatenation
- keep Docker built-in PostgreSQL config on the same DSN path
- add tests for PostgreSQL credentials/database escaping and IPv6 hosts

## Tests
- go test ./internal/install
- go test ./...

Closes #287