### PR TITLE
fix: 用户更新头像/昵称时同步清除积分排行缓存

### DIFF
--- a/internal/cache/user_cache.go
+++ b/internal/cache/user_cache.go
@@ -71,6 +71,7 @@ func (c *userCache) Get(userId int64) *models.User {
 
 func (c *userCache) Invalidate(userId int64) {
 	c.cache.Invalidate(userId)
+	c.scoreRankCache.Invalidate("data")
 }
 
 func (c *userCache) GetScoreRank() []models.User {


### PR DESCRIPTION
### 问题

积分排行（`/topics/category/1`）中的用户头像和昵称在用户更新后仍显示旧数据。

### 根因

`internal/cache/user_cache.go` 中的 `scoreRankCache` 独立缓存了 `[]models.User` 值对象，设置了 **10 分钟自动刷新**。当用户更新头像/昵称时，`UserService` 调用 `cache.UserCache.Invalidate(userId)` 仅清除了单个用户缓存，`scoreRankCache` 中的旧数据副本未失效，导致积分排行接口始终返回 10 分钟前的旧数据。

### 修复

在 `Invalidate` 方法中追加 `c.scoreRankCache.Invalidate("data")`，用户资料更新时同步清除积分排行缓存。

```diff
 func (c *userCache) Invalidate(userId int64) {
 	c.cache.Invalidate(userId)
+	c.scoreRankCache.Invalidate("data")
 }
```

### 影响

仅下一次请求会查 DB（`SELECT * FROM users ORDER BY score DESC LIMIT 10`），用户更新资料是低频操作，无实际性能影响。
