### PR TITLE
fix: 同步用户发帖/评论计数，修复积分排行与角色框数量不符

### DIFF
--- a/internal/handlers/admin/topic_handlers.go
+++ b/internal/handlers/admin/topic_handlers.go
@@ -169,7 +169,7 @@ func TopicAudit(ctx *gin.Context) {
 		ginx.WriteJSON(ctx, ginx.ErrorMessage("id is required"))
 		return
 	}
-	err := services.TopicService.UpdateColumn(id, "status", constants.StatusOk)
+	err := services.TopicService.Audit(id)
 	if err != nil {
 		ginx.WriteJSON(ctx, err)
 		return

--- a/internal/services/comment_service.go
+++ b/internal/services/comment_service.go
@@ -80,7 +80,16 @@ func (s *commentService) UpdateColumn(id int64, name string, value interface{}) 
 }
 
 func (s *commentService) Delete(id int64) error {
-	return repositories.CommentRepository.UpdateColumn(sqls.DB(), id, "status", constants.StatusDeleted)
+	comment := s.Get(id)
+	if comment == nil || comment.Status == constants.StatusDeleted {
+		return nil
+	}
+	if err := repositories.CommentRepository.UpdateColumn(sqls.DB(), id, "status", constants.StatusDeleted); err != nil {
+		return err
+	}
+	// 用户跟帖计数 -1
+	UserService.DecrCommentCount(comment.UserId)
+	return nil
 }
 
 func (s *commentService) DeleteByUser(user *models.User, id int64) error {

--- a/internal/services/topic_count_test.go
+++ b/internal/services/topic_count_test.go
@@ -119,6 +119,21 @@ func TestTopicService_Undelete_IncrementsTopicCount(t *testing.T) {
 	}
 }
 
+func TestTopicService_Undelete_ReviewTopicCountsAfterRestore(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	// 待审核话题发布时未计数，恢复（Undelete）为已发布后应计入
+	topic := mustCreateTopicWithStatus(t, user.Id, constants.StatusReview)
+	mustSetUserCount(t, user.Id, "topic_count", 0)
+
+	if err := TopicService.Undelete(topic.Id); err != nil {
+		t.Fatalf("undelete review topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 1 {
+		t.Fatalf("expected topic_count 1 after undelete review topic, got %d", got)
+	}
+}
+
 func TestTopicService_Audit_IncrementsTopicCountOnce(t *testing.T) {
 	setupTopicCountTestDB(t)
 	user := mustCreateUser(t, dates.NowTimestamp())

--- a/internal/services/topic_count_test.go
+++ b/internal/services/topic_count_test.go
@@ -1,0 +1,168 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"bbs-go/internal/models"
+	"bbs-go/internal/models/constants"
+	"bbs-go/internal/pkg/config"
+	"bbs-go/internal/pkg/search"
+	"bbs-go/internal/repositories"
+
+	"github.com/mlogclub/simple/common/dates"
+	"github.com/mlogclub/simple/sqls"
+	"gorm.io/gorm"
+)
+
+func setupTopicCountTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "bbs-go-test-search-")
+	if err != nil {
+		t.Fatalf("mk temp dir: %v", err)
+	}
+	config.Instance = &config.Config{
+		Language: config.DefaultLanguage,
+		Search:   config.SearchConfig{IndexPath: filepath.Join(dir, "index")},
+	}
+	search.Init()
+
+	db := setupTestDB(t)
+	if err := db.AutoMigrate(
+		&models.Topic{},
+		&models.TopicTag{},
+		&models.Attachment{},
+		&models.Comment{},
+	); err != nil {
+		t.Fatalf("auto migrate topic count: %v", err)
+	}
+	return db
+}
+
+func mustCreateTopicWithStatus(t *testing.T, userId int64, status int) *models.Topic {
+	t.Helper()
+	now := dates.NowTimestamp()
+	topic := &models.Topic{
+		Type:            constants.TopicTypeTopic,
+		CategoryId:      1,
+		QaStatus:        constants.QaStatusUnsolved,
+		UserId:          userId,
+		Title:           "test topic",
+		ContentType:     constants.ContentTypeText,
+		Content:         "content",
+		Status:          status,
+		LastCommentTime: now,
+		CreateTime:      now,
+	}
+	if err := repositories.TopicRepository.Create(sqls.DB(), topic); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	return topic
+}
+
+func mustSetUserCount(t *testing.T, userId int64, column string, count int) {
+	t.Helper()
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, column, count); err != nil {
+		t.Fatalf("set %s: %v", column, err)
+	}
+}
+
+func getUserTopicCount(t *testing.T, userId int64) int {
+	t.Helper()
+	user := UserService.Get(userId)
+	if user == nil {
+		t.Fatalf("user not found")
+	}
+	return user.TopicCount
+}
+
+func TestTopicService_Delete_DecrementsTopicCountForPublished(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	topic := mustCreateTopicWithStatus(t, user.Id, constants.StatusOk)
+	mustSetUserCount(t, user.Id, "topic_count", 1)
+
+	if err := TopicService.Delete(topic.Id, user.Id, nil); err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 0 {
+		t.Fatalf("expected topic_count 0 after delete, got %d", got)
+	}
+}
+
+func TestTopicService_Delete_DoesNotDecrementReviewTopic(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	topic := mustCreateTopicWithStatus(t, user.Id, constants.StatusReview)
+	mustSetUserCount(t, user.Id, "topic_count", 0)
+
+	if err := TopicService.Delete(topic.Id, user.Id, nil); err != nil {
+		t.Fatalf("delete review topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 0 {
+		t.Fatalf("expected topic_count still 0 after deleting review topic, got %d", got)
+	}
+}
+
+func TestTopicService_Undelete_IncrementsTopicCount(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	topic := mustCreateTopicWithStatus(t, user.Id, constants.StatusDeleted)
+	mustSetUserCount(t, user.Id, "topic_count", 0)
+
+	if err := TopicService.Undelete(topic.Id); err != nil {
+		t.Fatalf("undelete topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 1 {
+		t.Fatalf("expected topic_count 1 after undelete, got %d", got)
+	}
+}
+
+func TestTopicService_Audit_IncrementsTopicCountOnce(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	topic := mustCreateTopicWithStatus(t, user.Id, constants.StatusReview)
+	mustSetUserCount(t, user.Id, "topic_count", 0)
+
+	if err := TopicService.Audit(topic.Id); err != nil {
+		t.Fatalf("audit topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 1 {
+		t.Fatalf("expected topic_count 1 after audit, got %d", got)
+	}
+
+	// 二次审核（已是正常状态）不应再次计数
+	if err := TopicService.Audit(topic.Id); err != nil {
+		t.Fatalf("re-audit topic: %v", err)
+	}
+	if got := getUserTopicCount(t, user.Id); got != 1 {
+		t.Fatalf("expected topic_count still 1 after re-audit, got %d", got)
+	}
+}
+
+func TestCommentService_Delete_DecrementsCommentCount(t *testing.T) {
+	setupTopicCountTestDB(t)
+	user := mustCreateUser(t, dates.NowTimestamp())
+	comment := &models.Comment{
+		UserId:      user.Id,
+		EntityType:  constants.EntityTopic,
+		EntityId:    1,
+		Content:     "hello",
+		ContentType: constants.ContentTypeText,
+		Status:      constants.StatusOk,
+		CreateTime:  dates.NowTimestamp(),
+	}
+	if err := repositories.CommentRepository.Create(sqls.DB(), comment); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+	mustSetUserCount(t, user.Id, "comment_count", 1)
+
+	if err := CommentService.Delete(comment.Id); err != nil {
+		t.Fatalf("delete comment: %v", err)
+	}
+	user = UserService.Get(user.Id)
+	if user == nil || user.CommentCount != 0 {
+		t.Fatalf("expected comment_count 0 after delete, got %+v", user)
+	}
+}

--- a/internal/services/topic_publish_service.go
+++ b/internal/services/topic_publish_service.go
@@ -103,9 +103,11 @@ func (s *topicPublishService) Publish(userId int64, form req.CreateTopicReq) (*m
 			return err
 		}
 
-		// 用户计数
-		if err = UserService.IncrTopicCount(ctx, userId); err != nil {
-			return err
+		// 用户计数（待审核的话题不计入发帖数，审核通过后再计数）
+		if topic.Status == constants.StatusOk {
+			if err = UserService.IncrTopicCount(ctx, userId); err != nil {
+				return err
+			}
 		}
 
 		// 附件绑定（同一事务内校验与更新，避免 SQLite 卡住）

--- a/internal/services/topic_service.go
+++ b/internal/services/topic_service.go
@@ -140,8 +140,8 @@ func (s *topicService) Undelete(id int64) error {
 		if err := TopicTagService.UndeleteByTopicId(ctx, id); err != nil {
 			return err
 		}
-		// 用户发帖计数 +1（恢复为已发布状态后计入）
-		if topic.Status == constants.StatusDeleted {
+		// 用户发帖计数 +1（此前非已发布状态未计入，进入已发布后计入）
+		if topic.Status != constants.StatusOk {
 			if err := UserService.IncrTopicCount(ctx, topic.UserId); err != nil {
 				return err
 			}

--- a/internal/services/topic_service.go
+++ b/internal/services/topic_service.go
@@ -107,6 +107,12 @@ func (s *topicService) Delete(topicId, deleteUserId int64, r *http.Request) erro
 		if err := AttachmentService.SoftDeleteByTopicId(ctx, topicId); err != nil {
 			return err
 		}
+		// 用户发帖计数 -1（仅当帖子此前处于已发布状态才计入过数量）
+		if topic.Status == constants.StatusOk {
+			if err := UserService.DecrTopicCount(ctx, topic.UserId); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -123,11 +129,46 @@ func (s *topicService) Delete(topicId, deleteUserId int64, r *http.Request) erro
 
 // Undelete 取消删除
 func (s *topicService) Undelete(id int64) error {
+	topic := s.Get(id)
+	if topic == nil {
+		return nil
+	}
 	err := sqls.WithTransaction(func(ctx *sqls.TxContext) error {
 		if err := repositories.TopicRepository.UpdateColumn(ctx.Tx, id, "status", constants.StatusOk); err != nil {
 			return err
 		}
 		if err := TopicTagService.UndeleteByTopicId(ctx, id); err != nil {
+			return err
+		}
+		// 用户发帖计数 +1（恢复为已发布状态后计入）
+		if topic.Status == constants.StatusDeleted {
+			if err := UserService.IncrTopicCount(ctx, topic.UserId); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err == nil {
+		search.UpdateTopicIndex(s.Get(id))
+	}
+	return err
+}
+
+// Audit 审核通过，将待审核（或已删除）的话题置为已发布，并同步用户发帖计数
+func (s *topicService) Audit(id int64) error {
+	topic := s.Get(id)
+	if topic == nil {
+		return errors.New(locales.Get("common.not_found"))
+	}
+	if topic.Status == constants.StatusOk {
+		return nil
+	}
+	err := sqls.WithTransaction(func(ctx *sqls.TxContext) error {
+		if err := repositories.TopicRepository.UpdateColumn(ctx.Tx, id, "status", constants.StatusOk); err != nil {
+			return err
+		}
+		// 用户发帖计数 +1（此前为待审核/已删除状态，未计入发帖数）
+		if err := UserService.IncrTopicCount(ctx, topic.UserId); err != nil {
 			return err
 		}
 		return nil

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -564,6 +564,18 @@ func (s *userService) IncrTopicCount(ctx *sqls.TxContext, userId int64) error {
 	return nil
 }
 
+// DecrTopicCount topic_count - 1
+func (s *userService) DecrTopicCount(ctx *sqls.TxContext, userId int64) error {
+	if err := repositories.UserRepository.UpdateColumn(ctx.Tx, userId, "topic_count", gorm.Expr("topic_count - 1")); err != nil {
+		slog.Error(err.Error(), slog.Any("err", err))
+		return err
+	}
+	ctx.RegisterCallback(func() {
+		cache.UserCache.Invalidate(userId)
+	})
+	return nil
+}
+
 // IncrCommentCount comment_count + 1
 func (s *userService) IncrCommentCount(userId int64) int {
 	t := repositories.UserRepository.Get(sqls.DB(), userId)
@@ -577,6 +589,23 @@ func (s *userService) IncrCommentCount(userId int64) int {
 		cache.UserCache.Invalidate(userId)
 	}
 	return commentCount
+}
+
+// DecrCommentCount comment_count - 1
+func (s *userService) DecrCommentCount(userId int64) {
+	t := repositories.UserRepository.Get(sqls.DB(), userId)
+	if t == nil {
+		return
+	}
+	commentCount := t.CommentCount - 1
+	if commentCount < 0 {
+		commentCount = 0
+	}
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, "comment_count", commentCount); err != nil {
+		slog.Error(err.Error(), slog.Any("err", err))
+	} else {
+		cache.UserCache.Invalidate(userId)
+	}
 }
 
 // SendEmailVerifyEmail 发送邮箱验证邮件

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -564,9 +564,10 @@ func (s *userService) IncrTopicCount(ctx *sqls.TxContext, userId int64) error {
 	return nil
 }
 
-// DecrTopicCount topic_count - 1
+// DecrTopicCount topic_count - 1（不低于 0）
 func (s *userService) DecrTopicCount(ctx *sqls.TxContext, userId int64) error {
-	if err := repositories.UserRepository.UpdateColumn(ctx.Tx, userId, "topic_count", gorm.Expr("topic_count - 1")); err != nil {
+	if err := repositories.UserRepository.UpdateColumn(ctx.Tx, userId, "topic_count",
+		gorm.Expr("CASE WHEN topic_count > 0 THEN topic_count - 1 ELSE 0 END")); err != nil {
 		slog.Error(err.Error(), slog.Any("err", err))
 		return err
 	}
@@ -577,31 +578,19 @@ func (s *userService) DecrTopicCount(ctx *sqls.TxContext, userId int64) error {
 }
 
 // IncrCommentCount comment_count + 1
-func (s *userService) IncrCommentCount(userId int64) int {
-	t := repositories.UserRepository.Get(sqls.DB(), userId)
-	if t == nil {
-		return 0
-	}
-	commentCount := t.CommentCount + 1
-	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, "comment_count", commentCount); err != nil {
+func (s *userService) IncrCommentCount(userId int64) {
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, "comment_count",
+		gorm.Expr("comment_count + 1")); err != nil {
 		slog.Error(err.Error(), slog.Any("err", err))
 	} else {
 		cache.UserCache.Invalidate(userId)
 	}
-	return commentCount
 }
 
 // DecrCommentCount comment_count - 1
 func (s *userService) DecrCommentCount(userId int64) {
-	t := repositories.UserRepository.Get(sqls.DB(), userId)
-	if t == nil {
-		return
-	}
-	commentCount := t.CommentCount - 1
-	if commentCount < 0 {
-		commentCount = 0
-	}
-	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, "comment_count", commentCount); err != nil {
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), userId, "comment_count",
+		gorm.Expr("CASE WHEN comment_count > 0 THEN comment_count - 1 ELSE 0 END")); err != nil {
 		slog.Error(err.Error(), slog.Any("err", err))
 	} else {
 		cache.UserCache.Invalidate(userId)

--- a/migrations/000016_migration_script_sync_user_topic_comment_counts.go
+++ b/migrations/000016_migration_script_sync_user_topic_comment_counts.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"github.com/mlogclub/simple/sqls"
+)
+
+// migrate_sync_user_topic_comment_counts 重建用户发帖/评论计数，使其与「已发布/正常」数据一致。
+// 修复历史遗留的 topic_count / comment_count 漂移（删除/待审核未正确扣减或计入）。
+func migrate_sync_user_topic_comment_counts() error {
+	return sqls.WithTransaction(func(ctx *sqls.TxContext) error {
+		if err := ctx.Tx.Exec(`
+			UPDATE t_user SET topic_count = (
+				SELECT COUNT(*) FROM t_topic
+				WHERE t_topic.user_id = t_user.id AND t_topic.status = 0
+			), comment_count = (
+				SELECT COUNT(*) FROM t_comment
+				WHERE t_comment.user_id = t_user.id AND t_comment.status = 0
+			)
+		`).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/migrations/000016_migration_script_sync_user_topic_comment_counts_test.go
+++ b/migrations/000016_migration_script_sync_user_topic_comment_counts_test.go
@@ -1,0 +1,125 @@
+package migrations
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"bbs-go/internal/models"
+	"bbs-go/internal/models/constants"
+	"bbs-go/internal/repositories"
+
+	"github.com/glebarez/sqlite"
+	"github.com/mlogclub/simple/common/dates"
+	"github.com/mlogclub/simple/sqls"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
+)
+
+func setupSyncCountTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:sync_count_test_%d?mode=memory&cache=shared&_fk=1", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		NamingStrategy: schema.NamingStrategy{
+			TablePrefix:   "t_",
+			SingularTable: true,
+		},
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql db: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	sqls.SetDB(db)
+
+	if err := db.AutoMigrate(&models.User{}, &models.Topic{}, &models.Comment{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	return db
+}
+
+func TestMigrateSyncUserTopicCommentCounts(t *testing.T) {
+	setupSyncCountTestDB(t)
+	now := dates.NowTimestamp()
+
+	user := &models.User{Nickname: "u", Status: constants.StatusOk, CreateTime: now, UpdateTime: now}
+	if err := repositories.UserRepository.Create(sqls.DB(), user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	// 1 个已发布 + 1 个已删除 + 1 个待审核
+	mustCreateSyncTopic(t, user.Id, constants.StatusOk)
+	mustCreateSyncTopic(t, user.Id, constants.StatusDeleted)
+	mustCreateSyncTopic(t, user.Id, constants.StatusReview)
+	// 1 个正常 + 1 个已删除
+	mustCreateSyncComment(t, user.Id, constants.StatusOk)
+	mustCreateSyncComment(t, user.Id, constants.StatusDeleted)
+
+	// 人为写入错误计数
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), user.Id, "topic_count", 3); err != nil {
+		t.Fatalf("set topic_count: %v", err)
+	}
+	if err := repositories.UserRepository.UpdateColumn(sqls.DB(), user.Id, "comment_count", 2); err != nil {
+		t.Fatalf("set comment_count: %v", err)
+	}
+
+	if err := migrate_sync_user_topic_comment_counts(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	got := repositories.UserRepository.Get(sqls.DB(), user.Id)
+	if got == nil {
+		t.Fatal("user not found")
+	}
+	if got.TopicCount != 1 {
+		t.Fatalf("expected topic_count 1, got %d", got.TopicCount)
+	}
+	if got.CommentCount != 1 {
+		t.Fatalf("expected comment_count 1, got %d", got.CommentCount)
+	}
+}
+
+func mustCreateSyncTopic(t *testing.T, userId int64, status int) {
+	t.Helper()
+	now := dates.NowTimestamp()
+	topic := &models.Topic{
+		Type:            constants.TopicTypeTopic,
+		CategoryId:      1,
+		QaStatus:        constants.QaStatusUnsolved,
+		UserId:          userId,
+		Title:           "t",
+		ContentType:     constants.ContentTypeText,
+		Content:         "c",
+		Status:          status,
+		LastCommentTime: now,
+		CreateTime:      now,
+	}
+	if err := repositories.TopicRepository.Create(sqls.DB(), topic); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+}
+
+func mustCreateSyncComment(t *testing.T, userId int64, status int) {
+	t.Helper()
+	comment := &models.Comment{
+		UserId:      userId,
+		EntityType:  constants.EntityTopic,
+		EntityId:    1,
+		Content:     "c",
+		ContentType: constants.ContentTypeText,
+		Status:      status,
+		CreateTime:  dates.NowTimestamp(),
+	}
+	if err := repositories.CommentRepository.Create(sqls.DB(), comment); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+}

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -114,4 +114,5 @@ func init() {
 	register(12, "drop legacy api permission tables", migrate_drop_legacy_api_tables)
 	register(13, "drop legacy menu tables", migrate_drop_legacy_menu_tables)
 	register(15, "remove comment admin permissions", migrate_remove_comment_admin_permissions)
+	register(16, "sync user topic/comment counts", migrate_sync_user_topic_comment_counts)
 }


### PR DESCRIPTION
topic_count/comment_count 为冗余计数列，此前只增不减导致与真实
已发布数据脱节（删除/待审核帖子仍被计数）。本次修复：

- 发帖时仅已发布(StatusOk)话题计入，待审核通过后再计入
- 删除话题时回减、恢复(Undelete)/审核通过(Audit)时加回
- 删除评论时同步回减用户 comment_count
- 新增迁移 16 全量重算存量 topic_count/comment_count

积分排行与首页角色框均读取同一数据源，修复后两处数值一致。