### PR TITLE
fix: 修复 Firefox 中评论输入框 placeholder 遮挡发表/上传按钮

### DIFF
--- a/web/components/comment/text-editor.tsx
+++ b/web/components/comment/text-editor.tsx
@@ -223,7 +223,7 @@ export const TextEditor = React.forwardRef<
         value={content}
         placeholder={t("component.textEditor.placeholder")}
         className={cn(
-          "block w-full flex-1 resize-none rounded-t-lg border-0 bg-muted p-2.5 font-[inherit] leading-[1.8] text-foreground outline-0 overscroll-contain",
+          "block min-h-0 w-full flex-1 resize-none rounded-t-lg border-0 bg-muted p-2.5 font-[inherit] leading-[1.8] text-foreground outline-0 overscroll-contain",
           isFocus && "bg-background"
         )}
         disabled={disabled}
@@ -250,7 +250,7 @@ export const TextEditor = React.forwardRef<
       />
       {showImageUpload ? (
         <div
-          className="flex h-[90px] flex-wrap gap-2 overflow-auto p-2.5"
+          className="flex h-[90px] shrink-0 flex-wrap gap-2 overflow-auto p-2.5"
           onMouseDown={(event) => event.preventDefault()}
         >
           {currentImages.map((image, index) => (
@@ -296,7 +296,7 @@ export const TextEditor = React.forwardRef<
       ) : null}
       <div
         className={cn(
-          "flex h-9 items-center justify-between rounded-b-lg bg-muted px-2.5 py-[3px]",
+          "flex h-9 shrink-0 items-center justify-between rounded-b-lg bg-muted px-2.5 py-[3px]",
           isFocus && "bg-background"
         )}
       >


### PR DESCRIPTION
## 问题

在帖子详情页的评论输入框中，占位文本（placeholder）会覆盖底部的「发表」按钮和文件上传按钮。**仅 Firefox 出现，Chrome 正常**。

## 根因

评论输入框组件（\web/components/comment/text-editor.tsx\）是固定高度（90/120px）的 flex 纵向容器：textarea 用 \lex-1\ 撑满剩余空间，底部工具条固定 \h-9\。

Firefox 中 \<textarea>\ 的 \min-height\ 默认为 \uto\，会按其固有高度（默认 2 行 + 内边距 ≈ 74px）计算最小高度，导致 textarea 无法收缩到应有空间，把工具条顶出容器遮住。Chrome 对 \min-height: auto\ 的计算方式不同（textarea 视为可滚动元素，min-content 为 0），因此正常。

## 修复

\web/components/comment/text-editor.tsx\：
- textarea 添加 \min-h-0\，允许在 flex 布局中正常收缩
- 底部工具条 \h-9\ 与图片上传区 \h-[90px]\ 添加 \shrink-0\，防止被压缩

## 验证

- 本地 \pnpm typecheck\ / \pnpm lint\ 通过
- 仅影响评论输入框（含回复编辑器），发帖/文章的富文本编辑器走 \simple-editor\ 其他组件，不受影响